### PR TITLE
fix synapse autocomplete duplicates

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -153,18 +153,7 @@ class MainController < ApplicationController
     if term && !term.empty?
       @synapses = policy_scope(Synapse).where('LOWER("desc") like ?', '%' + term.downcase + '%').order('"desc"')
 
-      # remove any duplicate synapse types that just differ by
-      # leading or trailing whitespaces
-      collectedDesc = []
-      @synapses.to_a.uniq(&:desc).delete_if do |s|
-        desc = s.desc.nil? || s.desc == '' ? '' : s.desc.strip
-        if collectedDesc.index(desc).nil?
-          collectedDesc.push(desc)
-          false # return this value
-        else
-          true # return this value
-        end
-      end
+      @synapses = @synapses.uniq(&:desc)
     elsif topic1id && !topic1id.empty?
       @one = policy_scope(Synapse).where('node1_id = ? AND node2_id = ?', topic1id, topic2id)
       @two = policy_scope(Synapse).where('node2_id = ? AND node1_id = ?', topic1id, topic2id)

--- a/app/controllers/synapses_controller.rb
+++ b/app/controllers/synapses_controller.rb
@@ -20,6 +20,7 @@ class SynapsesController < ApplicationController
   def create
     @synapse = Synapse.new(synapse_params)
     @synapse.desc = '' if @synapse.desc.nil?
+    @synapse.desc.strip! # no trailing/leading whitespace
     authorize @synapse
 
     respond_to do |format|


### PR DESCRIPTION
there were 2 issues. one is synapses with leading/trailing whitespace. I've run a script on production to strip existing leading/trailing whitespace from synapse descs.

The second issue was that this code wasn't actually modifying the @synapses array, and collectedDesc wasn't doing anything. So the new line in main_controller.rb will be more effective than the old code.