### PR TITLE
multi-buildpack setup for heroku:

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,1 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs.git
 https://github.com/heroku/heroku-buildpack-ruby.git

--- a/lib/tasks/extensions.rake
+++ b/lib/tasks/extensions.rake
@@ -1,0 +1,8 @@
+namespace :assets do
+  task :js_compile do
+    system "npm install"
+    system "npm run build"
+  end
+end
+
+Rake::Task[:'assets:precompile'].enhance([:'assets:js_compile'])


### PR DESCRIPTION
heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi.git

will set it up

also override `rake assets:precompile` so it will compile npm first.