### PR TITLE
fix login redirect loop

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
   helper_method :admin?
 
   def after_sign_in_path_for(resource)
-    sign_in_url = url_for(action: 'new', controller: 'sessions', only_path: false, protocol: 'https')
+    sign_in_url = url_for(action: 'new', controller: 'sessions', only_path: false)
 
     if request.referer == sign_in_url
       super


### PR DESCRIPTION
The loop only came up on http:// versions of metamaps (heroku staging and dev envs), and further only if you logged in from /login (much more likely on the mobile view, since it pops up in a box on the homepage in desktop view).

This fixes it in any case