### PR TITLE
make it so using the 'load-page-without-refresh' is opt-in, not opt out

### DIFF
--- a/app/assets/javascripts/src/Metamaps.Router.js
+++ b/app/assets/javascripts/src/Metamaps.Router.js
@@ -263,6 +263,6 @@
       pushState: true,
       root: '/'
     })
-    $(document).on('click', 'a:not([data-bypass])', Metamaps.Router.intercept)
+    $(document).on('click', 'a[data-router="true"]', Metamaps.Router.intercept)
   }
 })()

--- a/app/views/admin/_adminpanel.html.erb
+++ b/app/views/admin/_adminpanel.html.erb
@@ -1,6 +1,6 @@
-<%= link_to 'Metacode Sets', metacode_sets_path, { :class => 'button', 'data-bypass' => 'true' }%>
-<%= link_to 'New Set', new_metacode_set_path, { :class => 'button', 'data-bypass' => 'true' }%>
-<%= link_to 'Metacodes', metacodes_path, { :class => 'button', 'data-bypass' => 'true' }%>
-<%= link_to 'New Metacode', new_metacode_path, { :class => 'button', 'data-bypass' => 'true' }%>
+<%= link_to 'Metacode Sets', metacode_sets_path, { :class => 'button' }%>
+<%= link_to 'New Set', new_metacode_set_path, { :class => 'button' }%>
+<%= link_to 'Metacodes', metacodes_path, { :class => 'button' }%>
+<%= link_to 'New Metacode', new_metacode_path, { :class => 'button' }%>
 <div class='clearfloat'></div>
 <br />

--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -30,7 +30,7 @@
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <%= f.submit t('doorkeeper.applications.buttons.submit'), class: "btn btn-primary" %>
-      <%= link_to t('doorkeeper.applications.buttons.cancel'), oauth_applications_path, :class => "button link-button red-button", :data => { :bypass => 'true' } %>
+      <%= link_to t('doorkeeper.applications.buttons.cancel'), oauth_applications_path, :class => "button link-button red-button" %>
     </div>
   </div>
 <% end %>

--- a/app/views/doorkeeper/applications/index.html.erb
+++ b/app/views/doorkeeper/applications/index.html.erb
@@ -15,14 +15,14 @@
   <tbody>
   <% @applications.each do |application| %>
     <tr id="application_<%= application.id %>">
-      <td><%= link_to application.name, oauth_application_path(application), :data => { :bypass => 'true' } %></td>
+      <td><%= link_to application.name, oauth_application_path(application) %></td>
       <td><%= application.redirect_uri %></td>
       <td><%= render 'delete_form', application: application %></td>
     </tr>
   <% end %>
   </tbody>
 </table>
-<%= link_to t('.new'), new_oauth_application_path, class: 'button link-button', :data => { :bypass => 'true' } %>
+<%= link_to t('.new'), new_oauth_application_path, class: 'button link-button' %>
 </div>
 </div>
 <%= render 'script' %>

--- a/app/views/doorkeeper/applications/new.html.erb
+++ b/app/views/doorkeeper/applications/new.html.erb
@@ -1,6 +1,6 @@
 <div id="yield">
 <div class="centerContent">
-<%= link_to t('doorkeeper.applications.buttons.back'), oauth_applications_path(), class: 'button link-button button-margin', :data => { :bypass => 'true' } %>
+<%= link_to t('doorkeeper.applications.buttons.back'), oauth_applications_path(), class: 'button link-button button-margin' %>
 <div class="page-header">
   <h2><%= t('.title') %></h2>
 </div>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -1,7 +1,7 @@
 <div id="yield">
 <div class="centerContent showApp">
 
-  <%= link_to t('doorkeeper.applications.buttons.back'), oauth_applications_path(), class: 'button link-button button-margin', :data => { :bypass => 'true' } %>
+  <%= link_to t('doorkeeper.applications.buttons.back'), oauth_applications_path(), class: 'button link-button button-margin' %>
 
   <div class="page-header">
     <h2><%= t('.title', name: @application.name) %></h2>
@@ -23,13 +23,13 @@
             <code><%= uri %></code>
           </td>
           <td>
-            <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code'), class: 'button link-button', target: '_blank', :data => { :bypass => 'true' } %>
+            <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code'), class: 'button link-button', target: '_blank' %>
           </td>
         </tr>
       <% end %>
     </table>
 
-    <div class="inline-button"><%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(@application), class: 'button link-button', :data => { :bypass => 'true' } %></div>
+    <div class="inline-button"><%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(@application), class: 'button link-button' %></div>
 
     <div class="inline-button"><%= render 'delete_form', application: @application, submit_btn_css: 'button red-button' %></div>
 </div>

--- a/app/views/layouts/_account.html.erb
+++ b/app/views/layouts/_account.html.erb
@@ -10,12 +10,12 @@
   <ul>
     <li class="accountListItem accountSettings">
       <div class="accountIcon"></div>
-      <%= link_to "Account", edit_user_url(account), :data => { :bypass => 'true'} %>
+      <%= link_to "Account", edit_user_url(account) %>
     </li>
     <% if account.admin %>
       <li class="accountListItem accountAdmin">
         <div class="accountIcon"></div>
-        <%= link_to "Admin", metacodes_path, :data => { :bypass => 'true'} %>
+        <%= link_to "Admin", metacodes_path %>
       </li>
     <% end %>
     <li class="accountListItem accountInvite openLightbox" data-open="invite">
@@ -24,7 +24,7 @@
     </li>
     <li class="accountListItem accountLogout">
       <div class="accountIcon"></div>
-      <%= link_to "Sign Out", "/logout", id: "Logout", :data => { :bypass => 'true'} %>
+      <%= link_to "Sign Out", "/logout", id: "Logout" %>
     </li>
   </ul>
 <% else %>
@@ -47,8 +47,7 @@
         <div class="clearfloat"></div>
         <div class="accountForgotPass">
           <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
-            <%= link_to "Forgot password?", new_password_path(resource_name), 
-              :data => { :bypass => 'true'} %>
+            <%= link_to "Forgot password?", new_password_path(resource_name) %>
           <% end -%>
         </div>
   <% end %>

--- a/app/views/layouts/_lightboxes.html.erb
+++ b/app/views/layouts/_lightboxes.html.erb
@@ -57,7 +57,7 @@
             </a>
           </li>
           <li>
-            <a id="lightbox_term" data-bypass="true" href="https://metamaps.cc/maps/331" target="_blank">
+            <a id="lightbox_term" href="https://metamaps.cc/maps/331" target="_blank">
               <div class="lightboxAboutIcon"></div>
               terms
             </a>

--- a/app/views/layouts/_mobilemenu.html.erb
+++ b/app/views/layouts/_mobilemenu.html.erb
@@ -8,7 +8,7 @@
   <ul>
     <% if not current_user %>
       <li>
-        <%= link_to "Home", root_path, :data => { :bypass => 'true'} %>
+        <%= link_to "Home", root_path %>
       </li>
     <% end %>
     <% if current_user %>
@@ -18,34 +18,34 @@
          <span><%= current_user.name %></span>
       </li>
       <li>
-        <%= link_to "My Maps", explore_mine_path %>
+        <%= link_to "My Maps", explore_mine_path, :data => { :router => 'true'} %>
       </li>
       <li>
-        <%= link_to "Shared With Me", explore_shared_path %>
+        <%= link_to "Shared With Me", explore_shared_path, :data => { :router => 'true'} %>
       </li>
     <% end %>
     <li>
-      <%= link_to "Recently Active", explore_active_path %>
+      <%= link_to "Recently Active", explore_active_path, :data => { :router => 'true'} %>
     </li>
     <% if not current_user %>
       <li>
-        <%= link_to "Featured Maps", explore_featured_path %>
+        <%= link_to "Featured Maps", explore_featured_path, :data => { :router => 'true'} %>
       </li>
     <% end %>
     <% if not current_user %>
       <li>
-        <%= link_to "Request Invite", request_path, :data => { :bypass => 'true'} %>
+        <%= link_to "Request Invite", request_path %>
       </li>
       <li>
-        <%= link_to "Login", new_user_session_path, :data => { :bypass => 'true'} %>
+        <%= link_to "Login", new_user_session_path %>
       </li>
     <% end %>
     <% if current_user %>
       <li>
-        <%= link_to "Account", edit_user_url(current_user), :data => { :bypass => 'true'} %>
+        <%= link_to "Account", edit_user_url(current_user) %>
       </li>
       <li>
-        <%= link_to "Sign Out", "/logout", id: "Logout", :data => { :bypass => 'true'} %>
+        <%= link_to "Sign Out", "/logout", id: "Logout" %>
       </li>
     <% end %>
   </ul>

--- a/app/views/layouts/_templates.html.erb
+++ b/app/views/layouts/_templates.html.erb
@@ -47,7 +47,7 @@
     </script>
     
     <script type="text/template" id="mapCardTemplate">
-  <a href="/maps/{{id}}">
+  <a href="/maps/{{id}}" data-router="true">
   <div class="permission {{editPermission}}"> <!-- must be canEdit or cannotEdit -->
 	  <div class="mapCard">                                                   
       <span class="title" title="{{fullName}}">                                                  
@@ -248,7 +248,7 @@
                 <div class="metacodeSelect">{{{metacode_select}}}</div>
             </div>
             <div class="linkItem contributor">
-                <a href="/explore/mapper/{{userid}}"><img src="<%= asset_path('user.png') %>" class="contributorIcon" width="32" height="32" /></a>
+                <a href="/explore/mapper/{{userid}}" target="_blank"><img src="<%= asset_path('user.png') %>" class="contributorIcon" width="32" height="32" /></a>
                 <div class="contributorName">{{username}}</div>
             </div>
             <div class="linkItem mapCount">                  
@@ -258,7 +258,7 @@
                 <div class="tip"><ul>{{{inmaps}}}</ul></div>                              
             </div>
 
-            <a href="/topics/{{id}}" class="linkItem synapseCount">
+            <a href="/topics/{{id}}" target="_blank" class="linkItem synapseCount">
               <div class="synapseCountIcon"></div>
               {{synapse_count}}
               <div class="tip">Click to see this topics synapses</div>

--- a/app/views/layouts/_upperelements.html.erb
+++ b/app/views/layouts/_upperelements.html.erb
@@ -4,7 +4,7 @@
 <div class="upperLeftUI">
   <!-- home button -->
   <div class="homeButton">
-    <a href="<%= root_url %>" <% if !current_user || appsPage %><%= 'data-bypass=true' %><% end %>>METAMAPS</a>
+    <a href="<%= root_url %>" <% if current_user && !appsPage %><%= 'data-router=true' %><% end %>>METAMAPS</a>
   </div> <!-- end homeButton -->
 
   <!-- search box -->
@@ -39,7 +39,7 @@
 
   <% if current_user %>
   <!-- create new map -->
-  <a href="<%= new_map_path %>" data-bypass="true" target="_blank" class="addMap upperRightEl upperRightIcon">
+  <a href="<%= new_map_path %>" target="_blank" class="addMap upperRightEl upperRightIcon">
     <div class="tooltipsUnder">
       Create New Map
     </div>

--- a/app/views/main/home.html.erb
+++ b/app/views/main/home.html.erb
@@ -21,8 +21,8 @@
         <h3>Who finds it useful?</h3>
         <p>Designers, inventors, artists, educators, strategists, consultants, facilitators, entrepreneurs, systems thinkers, changemakers, analysts, students, researchers... maybe you!</p>
         <button type="button" class="button learnMoreCTA" onclick="Metamaps.GlobalUI.openLightbox('about');">LEARN MORE</button>
-        <a href="/explore/featured" class="exploreFeaturedCTA">EXPLORE FEATURED MAPS</a>
-        <a href="/request" class="requestInviteCTA" data-bypass="true">REQUEST INVITE</a>
+        <a href="/explore/featured" data-router="true" class="exploreFeaturedCTA">EXPLORE FEATURED MAPS</a>
+        <a href="/request" class="requestInviteCTA">REQUEST INVITE</a>
       </div>
       <div class="clearfloat"></div>
     </div>

--- a/app/views/metacode_sets/_form.html.erb
+++ b/app/views/metacode_sets/_form.html.erb
@@ -83,7 +83,7 @@
   
   <div class="actions">
     <%= link_to 'Cancel', metacode_sets_path, 
-        { :class => 'button', 'data-bypass' => 'true' } %>
+        { :class => 'button' } %>
     <%= f.submit :class => 'add', :onclick => "return Metamaps.Admin.validate();" %>
   </div>
 <% end %>

--- a/app/views/metacode_sets/index.html.erb
+++ b/app/views/metacode_sets/index.html.erb
@@ -14,11 +14,11 @@
       <td>
         <%= metacode_set.name %><br />
         <%= link_to 'Edit', 
-            edit_metacode_set_path(metacode_set), :data => { :bypass => 'true'} %>
+            edit_metacode_set_path(metacode_set) %>
         <br />
         <%= link_to 'Delete', 
             metacode_set, method: :delete,
-            data: { confirm: 'Are you sure?', bypass: 'true' } %>
+            data: { confirm: 'Are you sure?' } %>
       </td>
       <td class='metacodeSetDesc'><%= metacode_set.desc %></td>
       <td>

--- a/app/views/metacodes/_form.html.erb
+++ b/app/views/metacodes/_form.html.erb
@@ -37,7 +37,7 @@
     <div class="clearfloat"></div>
   </div>
   <div class="actions">
-    <%= link_to 'Cancel', metacodes_path, { :class => 'button', 'data-bypass' => 'true' } %>
+    <%= link_to 'Cancel', metacodes_path, { :class => 'button' } %>
     <%= f.submit :class => 'add' %>
   </div>
 <% end %>

--- a/app/views/metacodes/index.html.erb
+++ b/app/views/metacodes/index.html.erb
@@ -23,7 +23,7 @@
         <td></td>
       <% end %>
       <td><%= image_tag metacode.icon, width: 40 %></td>
-      <td><%= link_to 'Edit', edit_metacode_path(metacode), :data => { :bypass => 'true'} %></td>
+      <td><%= link_to 'Edit', edit_metacode_path(metacode) %></td>
     </tr>
   <% end %>
   </table>

--- a/app/views/shared/_cheatsheet.html.erb
+++ b/app/views/shared/_cheatsheet.html.erb
@@ -153,42 +153,42 @@
 <div id="moreResources">
     <p>For more information about Metamaps.cc, visit our Knowledge Base or skip directly to a section by clicking on one of the categories below.</p>
     <div class="resourcesColumnOne resourcesColumn">
-        <a href="http://metamapscc.uservoice.com/forums/262715-general" target="_blank" data-bypass="true" class="button">Feedback Forums</a>
+        <a href="http://metamapscc.uservoice.com/forums/262715-general" target="_blank" class="button">Feedback Forums</a>
         <ul>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/61031-getting-started" target="_blank" data-bypass="true">Getting Started</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/61031-getting-started" target="_blank">Getting Started</a>
             </li>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63372-key-fundamentals" target="_blank" data-bypass="true">Key Fundamentals</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63372-key-fundamentals" target="_blank">Key Fundamentals</a>
             </li>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/61033-best-practices" target="_blank" data-bypass="true">Best Practices</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/61033-best-practices" target="_blank">Best Practices</a>
             </li>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63377-general-troubleshooting" target="_blank" data-bypass="true">General Troubleshooting</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63377-general-troubleshooting" target="_blank">General Troubleshooting</a>
             </li>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63443-applications-use-cases" target="_blank" data-bypass="true">Applications & Use Cases</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63443-applications-use-cases" target="_blank">Applications & Use Cases</a>
             </li>
         </ul>
     </div>
     <div class="resourcesColumnTwo resourcesColumn">
-        <a href="http://metamapscc.uservoice.com/knowledgebase" target="_blank" data-bypass="true" class="button">KNOWLEDGE BASE</a>
+        <a href="http://metamapscc.uservoice.com/knowledgebase" target="_blank"  class="button">KNOWLEDGE BASE</a>
         <ul>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63440-general-questions" target="_blank" data-bypass="true">General Questions</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63440-general-questions" target="_blank">General Questions</a>
             </li>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63375-getting-involved" target="_blank" data-bypass="true">Getting Involved</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63375-getting-involved" target="_blank">Getting Involved</a>
             </li>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63376-project-organization-governance" target="_blank" data-bypass="true">Organization & Governance</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63376-project-organization-governance" target="_blank">Organization & Governance</a>
             </li>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63378-technical-infrastructure" target="_blank" data-bypass="true">Technical Infrastructure</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63378-technical-infrastructure" target="_blank">Technical Infrastructure</a>
             </li>
             <li>
-                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63587-theory-references" target="_blank" data-bypass="true">References & Key Theory</a>
+                <a href="http://metamapscc.uservoice.com/knowledgebase/topics/63587-theory-references" target="_blank">References & Key Theory</a>
             </li>
         </ul>
     </div>

--- a/app/views/shared/_switchmetacodes.html.erb
+++ b/app/views/shared/_switchmetacodes.html.erb
@@ -19,9 +19,9 @@
 <div id="metacodeSwitchTabs">
   <ul>
     <% allMetacodeSets.each do |m| %>
-    <li><a href="#metacodeSwitchTabs<%= m.id %>" data-set-id="<%= m.id %>" data-bypass="true"><%= m.name %></a></li>
+    <li><a href="#metacodeSwitchTabs<%= m.id %>" data-set-id="<%= m.id %>"><%= m.name %></a></li>
     <% end %>
-    <li><a href="#metacodeSwitchTabsCustom" data-set-id="custom" data-bypass="true" id="metacodeSetCustom">CUSTOM SELECTION</a></li>
+    <li><a href="#metacodeSwitchTabsCustom" data-set-id="custom" id="metacodeSetCustom">CUSTOM SELECTION</a></li>
   </ul>
   <% allMetacodeSets.each_with_index do |m, localindex| %>
   <div id="metacodeSwitchTabs<%= m.id %>" 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -23,7 +23,7 @@
 
   <div><%= f.submit "Sign up!" %></div>
   
-  <div class = "smallText"><br />Don't have an access code?<br /><a href="/request" data-bypass="true">Request an Invite</a></div>
+  <div class = "smallText"><br />Don't have an access code?<br /><a href="/request">Request an Invite</a></div>
 <% end %>
 </div>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -24,8 +24,7 @@
   <div class="clearfloat"></div>
   <div class="accountForgotPass">
     <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
-      <%= link_to "Forgot password?", new_password_path(resource_name), 
-        :data => { :bypass => 'true'} %>
+      <%= link_to "Forgot password?", new_password_path(resource_name) %>
     <% end -%>
   </div>
 <% end %>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -39,21 +39,25 @@ class Header extends Component {
             <MapLink show={signedIn && explore}
               href="/explore/mine"
               linkClass={activeClass("my")}
+              data-router="true"
               text="My Maps"
             />
             <MapLink show={signedIn && explore}
               href="/explore/shared"
               linkClass={activeClass("shared")}
+              data-router="true"
               text="Shared With Me"
             />
             <MapLink show={explore}
               href={signedIn ? "/" : "/explore/active"}
               linkClass={activeClass("active")}
+              data-router="true"
               text="Recently Active"
             />
             <MapLink show={!signedIn && explore}
               href="/explore/featured"
               linkClass={activeClass("featured")}
+              data-router="true"
               text="Featured Maps"
             />
       
@@ -68,13 +72,11 @@ class Header extends Component {
             <MapLink show={apps}
               href="/oauth/applications"
               linkClass={"activeMaps exploreMapsButton"  + (section == "registered" ? " active" : "")}
-              data-bypass="true"
               text="Registered Apps"
             />
             <MapLink show={apps}
               href="/oauth/applications"
               linkClass={"activeMaps exploreMapsButton"  + (section == "authorized" ? " active" : "")}
-              data-bypass="true"
               text="Authorized Apps"
             />
           </div>


### PR DESCRIPTION
this is because we are going to be adding more pages, and there are relatively few kinds of links that require this 'no-reload' navigation, so it is better to have it be opt-in in the code, than opt-out. otherwise it would get easily missed by people adding new links

so now instead of using `data-bypass=true` to force a refresh when you click a link, you use
`data-router=true` to force it load the other content without refreshing. Keep in mind this only works for routes which have a defined function in `Metamaps.Router.js`

for further clarity on this: we currently use `data-router` for four areas of the app, and switching between them: 
- the homepage
- the explore maps pages
- loading a map
- loading a topic