### PR TITLE
allow maps to be referenced within other maps easier, and created using topic creation

### DIFF
--- a/app/assets/javascripts/src/Metamaps.Erb.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Erb.js.erb
@@ -8,6 +8,7 @@
 window.Metamaps = window.Metamaps || {}
 Metamaps.Erb = {}
 Metamaps.Erb['REALTIME_SERVER'] = '<%= ENV['REALTIME_SERVER'] %>'
+Metamaps.Erb['RAILS_ENV'] = '<%= ENV['RAILS_ENV'] %>'
 Metamaps.Erb['junto_spinner_darkgrey.gif'] = '<%= asset_path('junto_spinner_darkgrey.gif') %>'
 Metamaps.Erb['user.png'] = '<%= asset_path('user.png') %>'
 Metamaps.Erb['icons/wildcard.png'] = '<%= asset_path('icons/wildcard.png') %>'

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -3,21 +3,23 @@ module TopicsHelper
   ## this one is for building our custom JSON autocomplete format for typeahead
   def autocomplete_array_json(topics)
     topics.map do |t|
+      is_map = t.is_a?(Map)
       {
         id: t.id,
         label: t.name,
         value: t.name,
         description: t.desc ? t.desc&.truncate(70) : '', # make this return matched results
-        type: t.metacode.name,
-        typeImageURL: t.metacode.icon,
-        permission: t.permission,
-        mapCount: t.maps.count,
-        synapseCount: t.synapses.count,
         originator: t.user.name,
         originatorImage: t.user.image.url(:thirtytwo),
-        rtype: :topic,
-        inmaps: t.inmaps,
-        inmapsLinks: t.inmapsLinks
+        permission: t.permission,
+
+        rtype: is_map ? 'map' : 'topic',
+        inmaps: is_map ? [] : t.inmaps,
+        inmapsLinks: is_map ? [] : t.inmapsLinks
+        type: is_map ? metamapsMetacode.name : t.metacode.name,
+        typeImageURL: is_map ? metamapMetacode.icon : t.metacode.icon,
+        mapCount: is_map ? 0 : t.maps.count,
+        synapseCount: is_map ? 0 : t.synapses.count,
       }
     end
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -15,6 +15,8 @@ class Topic < ApplicationRecord
 
   belongs_to :metacode
 
+  before_create :create_metamap?
+
   validates :permission, presence: true
   validates :permission, inclusion: { in: Perm::ISSIONS.map(&:to_s) }
 
@@ -128,4 +130,12 @@ class Topic < ApplicationRecord
   def mk_permission
     Perm.short(permission)
   end
+
+  protected
+    def create_metamap?
+      if link == '' and metacode.name == 'Metamap'
+        @map = Map.create({ name: name, permission: permission, desc: '', arranged: true, user_id: user_id })
+        self.link = Rails.application.routes.url_helpers.map_url(:host => ENV['MAILER_DEFAULT_URL'], :id => @map.id)
+      end
+    end
 end

--- a/frontend/src/Metamaps/Create.js
+++ b/frontend/src/Metamaps/Create.js
@@ -194,7 +194,14 @@ const Create = {
 
       // tell the autocomplete to submit the form with the topic you clicked on if you pick from the autocomplete
       $('#topic_name').bind('typeahead:select', function (event, datum, dataset) {
-        Topic.getTopicFromAutocomplete(datum.id)
+        if (datum.rtype === 'topic') {
+          Topic.getTopicFromAutocomplete(datum.id)
+        } else if (datum.rtype === 'map') {
+          Topic.getMapFromAutocomplete({
+            id: datum.id,
+            name: datum.label
+          })
+        }
       })
 
       // initialize metacode spinner and then hide it

--- a/frontend/src/Metamaps/Topic.js
+++ b/frontend/src/Metamaps/Topic.js
@@ -370,6 +370,37 @@ const Topic = {
 
     self.renderTopic(mapping, topic, true, true)
   },
+  getMapFromAutocomplete: function (data) {
+    var self = Metamaps.Topic
+
+    // hide the 'double-click to add a topic' message
+    Metamaps.GlobalUI.hideDiv('#instructions')
+
+    $(document).trigger(Metamaps.Map.events.editedByActiveMapper)
+
+    var metacode = Metamaps.Metacodes.findWhere({ name: 'Metamap' })
+
+    var topic = new Metamaps.Backbone.Topic({
+      name: data.name,
+      metacode_id: metacode.id,
+      defer_to_map_id: Metamaps.Active.Map.id,
+      link: window.location.origin + '/maps/' + data.id
+    })
+    Metamaps.Topics.add(topic)
+
+    var mapping = new Metamaps.Backbone.Mapping({
+      xloc: Metamaps.Create.newTopic.x,
+      yloc: Metamaps.Create.newTopic.y,
+      mappable_id: topic.cid,
+      mappable_type: 'Topic',
+    })
+    Metamaps.Mappings.add(mapping)
+
+    // these can't happen until the value is retrieved, which happens in the line above
+    Metamaps.Create.newTopic.hide()
+
+    self.renderTopic(mapping, topic, true, true) // this function also includes the creation of the topic in the database
+  },
   getTopicFromSearch: function (event, id) {
     var self = Topic
 

--- a/frontend/src/Metamaps/TopicCard.js
+++ b/frontend/src/Metamaps/TopicCard.js
@@ -135,8 +135,12 @@ const TopicCard = {
           loader.setRange(0.9); // default is 1.3
           loader.show() // Hidden by default
           var e = embedly('card', document.getElementById('embedlyLink'))
-          if (!e) {
+          if (!e && Metamaps.Erb.RAILS_ENV != 'development') {
             self.handleInvalidLink()
+          }
+          else if (!e) {
+            $('#embedlyLink').attr('target', '_blank').html(topic.get('link')).show()
+            $('#embedlyLinkLoader').hide()
           }
         }
       }, 100)
@@ -154,8 +158,11 @@ const TopicCard = {
       loader.show() // Hidden by default
       var e = embedly('card', document.getElementById('embedlyLink'))
       self.showLinkRemover()
-      if (!e) {
+      if (!e && Metamaps.Erb.RAILS_ENV != 'development') {
         self.handleInvalidLink()
+      } else if (!e) {
+        $('#embedlyLink').attr('target', '_blank').html(topic.get('link')).show()
+        $('#embedlyLinkLoader').hide()
       }
     }
 


### PR DESCRIPTION
so this means two things: 

1. when you create a Map, using the carousel, it creates a map, as well as a topic, and links the topic to the map
2. the topic autocomplete includes Maps as results, and thus allows quick referencing of maps within other maps. If there is no topic referencing that map, it will create one, and auto-link it to the map

@devvmh I just realized this afterwards, but would it be better to not handle this in the Topic model, in order to avoid side effects down the road? 