### PR TITLE
fix @maps serialization bug

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -19,7 +19,7 @@ class MapsController < ApplicationController
         redirect_to(root_url) && return if authenticated?
         respond_with(@maps, @user)
       end
-      format.json { render json: @maps }
+      format.json { render json: @maps.to_json }
     end
   end
 
@@ -33,7 +33,7 @@ class MapsController < ApplicationController
 
     respond_to do |format|
       format.html { respond_with(@maps, @user) }
-      format.json { render json: @maps }
+      format.json { render json: @maps.to_json }
     end
   end
 
@@ -51,7 +51,7 @@ class MapsController < ApplicationController
 
     respond_to do |format|
       format.html { respond_with(@maps, @user) }
-      format.json { render json: @maps }
+      format.json { render json: @maps.to_json }
     end
   end
 
@@ -69,7 +69,7 @@ class MapsController < ApplicationController
 
     respond_to do |format|
       format.html { respond_with(@maps, @user) }
-      format.json { render json: @maps }
+      format.json { render json: @maps.to_json }
     end
   end
 
@@ -88,7 +88,7 @@ class MapsController < ApplicationController
 
     respond_to do |format|
       format.html { respond_with(@maps, @user) }
-      format.json { render json: @maps }
+      format.json { render json: @maps.to_json }
     end
   end
 
@@ -101,7 +101,7 @@ class MapsController < ApplicationController
 
     respond_to do |format|
       format.html { respond_with(@maps, @user) }
-      format.json { render json: @maps }
+      format.json { render json: @maps.to_json }
     end
   end
 

--- a/spec/controllers/maps_controller_spec.rb
+++ b/spec/controllers/maps_controller_spec.rb
@@ -8,6 +8,21 @@ RSpec.describe MapsController, type: :controller do
     sign_in create(:user)
   end
 
+  describe 'GET #activemaps' do
+    context 'always returns an array' do
+      it 'with 0 records' do
+        Map.delete_all
+        get :activemaps, format: :json
+        expect(JSON.parse(response.body)).to eq []
+      end
+      it 'with 1 record' do
+        map = create(:map)
+        get :activemaps, format: :json
+        expect(JSON.parse(response.body).class).to be Array
+      end
+    end
+  end
+
   describe 'POST #create' do
     context 'with valid params' do
       it 'creates a new Map' do


### PR DESCRIPTION
if @maps is empty, it returns {"maps":[]}, instead of [] like we expect
on the frontend.

This commit fixes this issue