### PR TITLE
Feature/fix map titles

### DIFF
--- a/frontend/src/Metamaps/Map/index.js
+++ b/frontend/src/Metamaps/Map/index.js
@@ -76,7 +76,7 @@ const Map = {
       var map = Active.Map
       var mapper = Active.Mapper
 
-      document.title = map.attributes.name + ' | Metamaps'
+      document.title = map.get('name') + ' | Metamaps'
 
       // add class to .wrapper for specifying whether you can edit the map
       if (map.authorizeToEdit(mapper)) {

--- a/frontend/src/Metamaps/Map/index.js
+++ b/frontend/src/Metamaps/Map/index.js
@@ -76,6 +76,8 @@ const Map = {
       var map = Active.Map
       var mapper = Active.Mapper
 
+      document.title = map.attributes.name + ' | Metamaps'
+
       // add class to .wrapper for specifying whether you can edit the map
       if (map.authorizeToEdit(mapper)) {
         $('.wrapper').addClass('canEditMap')

--- a/frontend/src/Metamaps/Router.js
+++ b/frontend/src/Metamaps/Router.js
@@ -157,8 +157,6 @@ const _Router = Backbone.Router.extend({
   maps: function (id) {
     clearTimeout(this.timeoutId)
 
-    document.title = 'Map ' + id + ' | Metamaps'
-
     this.currentSection = 'map'
     this.currentPage = id
 


### PR DESCRIPTION
This little change makes it so that maps launched from the explore maps page shows the map name in the browser tab, instead of the map id.