### PR TITLE
fix git versioning

### DIFF
--- a/app/assets/javascripts/src/Metamaps.Erb.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Erb.js.erb
@@ -18,3 +18,5 @@ Metamaps.Erb['sounds/MM_sounds.mp3'] = '<%= asset_path 'sounds/MM_sounds.mp3' %>
 Metamaps.Erb['sounds/MM_sounds.ogg'] = '<%= asset_path 'sounds/MM_sounds.ogg' %>'
 Metamaps.Metacodes = <%= Metacode.all.to_json.gsub(%r[(icon.*?)(\"},)], '\1?purple=stupid\2').html_safe %>
 Metamaps.VERSION = '<%= METAMAPS_VERSION %>'
+Metamaps.BUILD = '<%= METAMAPS_BUILD %>'
+Metamaps.LAST_UPDATED = '<%= METAMAPS_LAST_UPDATED %>'

--- a/app/views/layouts/_lightboxes.html.erb
+++ b/app/views/layouts/_lightboxes.html.erb
@@ -13,12 +13,14 @@
             <div id="leftAboutParms">
                 <p>STATUS: </p>
                 <p>VERSION:</p>
+                <p>BUILD:</p>
                 <p>LAST UPDATE:</p>
             </div>
 
             <div id="rightAboutParms">
                 <p>PRIVATE BETA</p>
                 <p><%= METAMAPS_VERSION %></p>
+                <p><%= METAMAPS_BUILD %></p>
                 <p><%= METAMAPS_LAST_UPDATED %></p>
             </div>
             <div class="clearfloat">

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
-METAMAPS_VERSION = '2 build `git log -1 --pretty=%H`'
+METAMAPS_VERSION = '2.9'
+METAMAPS_BUILD = `git log -1 --pretty=%H`.chomp.freeze
 METAMAPS_LAST_UPDATED = `git log -1 --pretty='%ad'`.split(' ').values_at(1, 2, 4).join(' ').freeze

--- a/frontend/src/Metamaps/index.js
+++ b/frontend/src/Metamaps/index.js
@@ -31,6 +31,7 @@ import Util from './Util'
 import Views from './Views'
 import Visualize from './Visualize'
 
+Metamaps = window.Metamaps || {}
 Metamaps.Account = Account
 Metamaps.Active = Active
 Metamaps.Admin = Admin


### PR DESCRIPTION
```
METAMAPS_VERSION = "2 build `git log ...`" # doesn't work
METAMAPS_VERSION = "2 build #{`git log ...`}" # works
```