### PR TITLE
Prevent default context menu from opening when topics/synapses are right-clicked

### DIFF
--- a/frontend/src/Metamaps/Map/index.js
+++ b/frontend/src/Metamaps/Map/index.js
@@ -39,7 +39,7 @@ const Map = {
     var self = Map
 
     // prevent right clicks on the main canvas, so as to not get in the way of our right clicks
-    $('#center-container').bind('contextmenu', function (e) {
+    $('#wrapper').on('contextmenu', function (e) {
       return false
     })
 


### PR DESCRIPTION
Prevents the default chrome context menu from appearing overtop the Metamaps context menu

This addresses issue #658 