### PR TITLE
Better default context menu suppression fix

### DIFF
--- a/frontend/src/Metamaps/Create.js
+++ b/frontend/src/Metamaps/Create.js
@@ -209,6 +209,7 @@ const Create = {
         bringToFront: true
       })
       $('.new_topic').hide()
+      $('#new_topic').attr('oncontextmenu','return false') //prevents the mouse up event from opening the default context menu on this element
     },
     name: null,
     newId: 1,

--- a/frontend/src/Metamaps/JIT.js
+++ b/frontend/src/Metamaps/JIT.js
@@ -888,6 +888,7 @@ const JIT = {
           var myY = e.clientY - 30
           $('#new_topic').css('left', myX + 'px')
           $('#new_topic').css('top', myY + 'px')
+          $('#new_topic').attr('oncontextmenu','return false') //prevents the mouse up event from opening the default context menu on this element
           Create.newTopic.x = eventInfo.getPos().x
           Create.newTopic.y = eventInfo.getPos().y
           Visualize.mGraph.plot()

--- a/frontend/src/Metamaps/JIT.js
+++ b/frontend/src/Metamaps/JIT.js
@@ -888,7 +888,6 @@ const JIT = {
           var myY = e.clientY - 30
           $('#new_topic').css('left', myX + 'px')
           $('#new_topic').css('top', myY + 'px')
-          $('#new_topic').attr('oncontextmenu','return false') //prevents the mouse up event from opening the default context menu on this element
           Create.newTopic.x = eventInfo.getPos().x
           Create.newTopic.y = eventInfo.getPos().y
           Visualize.mGraph.plot()

--- a/frontend/src/Metamaps/JIT.js
+++ b/frontend/src/Metamaps/JIT.js
@@ -1305,6 +1305,9 @@ const JIT = {
     // create new menu for clicked on node
     var rightclickmenu = document.createElement('div')
     rightclickmenu.className = 'rightclickmenu'
+    //prevent the custom context menu from immediately opening the default context menu as well
+    rightclickmenu.setAttribute('oncontextmenu','return false')
+    
     // add the proper options to the menu
     var menustring = '<ul>'
 
@@ -1550,6 +1553,8 @@ const JIT = {
     // create new menu for clicked on node
     var rightclickmenu = document.createElement('div')
     rightclickmenu.className = 'rightclickmenu'
+    //prevent the custom context menu from immediately opening the default context menu as well
+    rightclickmenu.setAttribute('oncontextmenu','return false')
 
     // add the proper options to the menu
     var menustring = '<ul>'

--- a/frontend/src/Metamaps/Map/index.js
+++ b/frontend/src/Metamaps/Map/index.js
@@ -38,6 +38,11 @@ const Map = {
   init: function () {
     var self = Map
 
+    // prevent right clicks on the main canvas, so as to not get in the way of our right clicks
+    $('#wrapper').on('contextmenu', function (e) {
+      return false
+    })
+
     $('.starMap').click(function () {
       if ($(this).is('.starred')) self.unstar()
       else self.star()

--- a/frontend/src/Metamaps/Map/index.js
+++ b/frontend/src/Metamaps/Map/index.js
@@ -38,11 +38,6 @@ const Map = {
   init: function () {
     var self = Map
 
-    // prevent right clicks on the main canvas, so as to not get in the way of our right clicks
-    $('#wrapper').on('contextmenu', function (e) {
-      return false
-    })
-
     $('.starMap').click(function () {
       if ($(this).is('.starred')) self.unstar()
       else self.star()


### PR DESCRIPTION
This is a much better context menu fix than the one I submitted last night. @Connoropolous was right that it was the div.rightclickmenu element that was triggering the unwanted context menu (When I looked at the target in the event object)...

However trying to add an event handler in the index.js file, as I was solving this problem initially, didn't work... I figured, maybe this contextmenu event was being triggered before I even had the chance to to add the event handler... So I went right back to the exact moment in the code where the div.rightclickmenu was created, and added the oncontextmenu="return false" attribute right afterwards...

This has solved the problem in my c9.io instance, and I'm no longer disabling the context menu on every div element either :P