### PR TITLE
Custom formatter for slack exception notifications

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery(with: :exception)
 
   before_action :invite_link
+  before_action :prepare_exception_notifier
   after_action :allow_embedding
 
   def default_serializer_options
@@ -81,5 +82,11 @@ class ApplicationController < ActionController::Base
     response.headers.except! 'X-Frame-Options'
     # or allow a whitelist
     # response.headers['X-Frame-Options'] = 'ALLOW-FROM http://blog.metamaps.cc'
+  end
+
+  def prepare_exception_notifier
+    request.env['exception_notifier.exception_data'] = {
+      current_user: current_user
+    }
   end
 end

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,6 +1,51 @@
 # frozen_string_literal: true
 require 'exception_notification/rails'
 
+module ExceptionNotifier
+  class MetamapsNotifier < SlackNotifier
+    def call(exception, options = {})
+      # trick original notifier to "ping" self, storing the result
+      # in @message_opts and then modifying the result
+      @old_notifier = @notifier
+      @notifier = self
+      super
+      @notifier = @old_notifier
+
+      @message_opts[:attachments][0][:fields] = new_fields(exception, options[:env])
+      @message_opts[:attachments][0][:text] = new_text(exception, options[:env])
+
+      @notifier.ping '', @message_opts
+    end
+
+    def ping(message, message_opts)
+      @message = message
+      @message_opts = message_opts
+    end
+
+    private
+
+    def new_fields(exception, env)
+      new_fields = []
+
+      backtrace = exception.backtrace.reject { |line| line !~ %r{metamaps/(app|config|lib)} }
+      backtrace = backtrace[0..3] if backtrace.length > 4
+      backtrace = "```\n#{backtrace.join("\n")}\n```"
+      new_fields << { title: 'Backtrace', value: backtrace }
+
+      user = env.dig('exception_notifier.exception_data', :current_user)
+      new_fields << { title: 'Current User', value: "`#{user.name} <#{user.email}>`" }
+
+      new_fields
+    end
+
+    def new_text(exception, _env)
+      text = @message_opts[:attachments][0][:text].chomp
+      text += ': ' + exception.message + "\n"
+      text
+    end
+  end
+end
+
 ExceptionNotification.configure do |config|
   # Ignore additional exception types.
   # ActiveRecord::RecordNotFound, AbstractController::ActionNotFound and
@@ -20,7 +65,7 @@ ExceptionNotification.configure do |config|
   # Notifiers ######
 
   if ENV['SLACK_EN_WEBHOOK_URL']
-    config.add_notifier :slack, webhook_url: ENV['SLACK_EN_WEBHOOK_URL']
+    config.add_notifier :metamaps, webhook_url: ENV['SLACK_EN_WEBHOOK_URL']
   end
 
   # Email notifier sends notifications by email.


### PR DESCRIPTION
https://github.com/smartinez87/exception_notification#slack-notifier

The latest exception notifier had a bug anyways, so writing a custom class was the most precise way to fix the format.

- [x] write a custom class that extends Slack Notifier to fix this issue