### PR TITLE
new map improvements

### DIFF
--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -9,7 +9,7 @@ class ExploreController < ApplicationController
 
   # GET /explore/active
   def active
-    @maps = map_scope(Map)
+    @maps = map_scope(Map.where.not(name: 'Untitled Map'))
 
     respond_to do |format|
       format.html do

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -12,7 +12,7 @@ class MainController < ApplicationController
           skip_policy_scope
           render 'main/home'
         else
-          @maps = policy_scope(Map).order(updated_at: :desc).page(1).per(20)
+          @maps = policy_scope(Map.where.not(name: 'Untitled Map')).order(updated_at: :desc).page(1).per(20)
           render 'explore/active'
         end
       end

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -2,18 +2,17 @@
 class MainController < ApplicationController
   before_action :authorize_main
   after_action :verify_authorized
-  after_action :verify_policy_scoped, only: [:home]
 
   # GET /
   def home
     respond_to do |format|
       format.html do
-        if !authenticated?
-          skip_policy_scope
-          render 'main/home'
-        else
-          @maps = policy_scope(Map.where.not(name: 'Untitled Map')).order(updated_at: :desc).page(1).per(20)
+        if authenticated?
+          @maps = policy_scope(Map).where.not(name: 'Untitled Map')
+                                   .order(updated_at: :desc).page(1).per(20)
           render 'explore/active'
+        else
+          render 'main/home'
         end
       end
     end

--- a/frontend/src/Metamaps/Map/InfoBox.js
+++ b/frontend/src/Metamaps/Map/InfoBox.js
@@ -38,6 +38,9 @@ const InfoBox = {
     if (querystring == 'new') { 
       self.open()
       $('.mapInfoBox').addClass('mapRequestTitle')
+      $('#mapInfoName').trigger('click')
+      $('#mapInfoName textarea').focus()
+      $('#mapInfoName textarea').select()
     }
   },
   toggleBox: function (event) {
@@ -139,7 +142,8 @@ const InfoBox = {
       // mobile menu
       $('#header_content').html(name)
       $('.mapInfoBox').removeClass('mapRequestTitle')
-      document.title = name + ' | Metamaps'
+      document.title = `${name} | Metamaps`
+      window.history.replaceState('', `${name} | Metamaps`, window.location.pathname)
     })
 
     $('.mapInfoDesc .best_in_place_desc').unbind('ajax:success').bind('ajax:success', function () {


### PR DESCRIPTION
- Hide maps with "Untitled Map" from the global view by default
- Remove the ?new from the url after the map info box is closed for the first time, so that refreshing the page won't pop it up again.
- When ?new is in the url, focus and select the text of Untitled Map after popping up the info box to make it easier to immediately add a title.

fixes most, but not quite everything, in #701 