### PR TITLE
speed up travis builds by excluding raml2html from npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
   - nvm use stable
-  - npm install
+  - npm install --no-optional
 script:
   - bundle exec rspec && bundle exec brakeman -q -z && npm test
 addons:

--- a/bin/build-apidocs.sh
+++ b/bin/build-apidocs.sh
@@ -2,4 +2,8 @@
 
 # Note: you need to run `npm install` before using this script or raml2html won't be installed
 
+if [[ ! -x ./node_modules/.bin/raml2html ]]; then
+  npm install
+fi
+
 ./node_modules/.bin/raml2html -i ./doc/api/api.raml -o ./public/api/index.html

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash": "4.16.1",
     "node-uuid": "1.4.7",
     "outdent": "0.2.1",
-    "raml2html": "^4.0.0-beta5",
     "react": "15.3.2",
     "react-dom": "15.3.2",
     "socket.io": "0.9.12",
@@ -43,5 +42,8 @@
     "eslint": "^3.5.0",
     "eslint-plugin-react": "^6.3.0",
     "mocha": "^3.0.2"
+  },
+  "optionalDependencies": {
+    "raml2html": "4.0.0-beta5"
   }
 }


### PR DESCRIPTION
Yup, looks like it saves 15s