### PR TITLE
add scripts from default rails install

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../config/application', __dir__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run


### PR DESCRIPTION
I ran `rspec` just now and my computer said:

```
Migrations are pending. To resolve this issue, run:

  bin/rails db:migrate RAILS_ENV=test
```

but I couldn't, because bin/rails didn't exist. So I ran `rails new` in another folder and copied these three scripts over.