### PR TITLE
fix topic autocomplete controller action

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -22,7 +22,7 @@ class TopicsController < ApplicationController
     end
     @all= @topics.to_a.concat(@maps.to_a).sort { |a, b| a.name <=> b.name }
     
-    render json: autocomplete_array_json(@all)
+    render json: autocomplete_array_json(@all).to_json
   end
 
   # GET topics/:id


### PR DESCRIPTION
fixes #765 

this change doesn't change anything, unless @all is an array, in which case the old behaviour was to return `{"":[]}` and the new behaviour is to return `[]`