### PR TITLE
This fix closes the topic creation spinner when the map is panned.

### DIFF
--- a/frontend/src/Metamaps/JIT.js
+++ b/frontend/src/Metamaps/JIT.js
@@ -1069,6 +1069,9 @@ const JIT = {
         Control.deselectAllEdges()
         Control.deselectAllNodes()
       }
+    } else {
+      // SINGLE CLICK, resulting from pan
+      Create.newTopic.hide()
     }
   }, // canvasClickHandler 
   updateTopicPositions: function (node, pos){


### PR DESCRIPTION
since, sometimes a click turns into a really small pan