### PR TITLE
overflow-y: hidden on body to prevent openLightbox from showing a scrollbar

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -82,7 +82,7 @@ body {
     font-family: 'din-medium', helvetica, sans-serif;
     color: #424242;
     -moz-osx-font-smoothing: grayscale;
-    overflow-x: hidden;
+    overflow: hidden;
 }
 h1,
 h2,


### PR DESCRIPTION
fixes #829

@connoropolous can you review? Maybe we can deploy this today and test on heroku over the weekend