### PR TITLE
[develop] show private, shared maps in All Maps

### DIFF
--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -9,7 +9,7 @@ class ExploreController < ApplicationController
 
   # GET /explore/active
   def active
-    @maps = map_scope(Map.where.not(name: 'Untitled Map').where.not(permission: 'private'))
+    @maps = map_scope(Map).where.not(name: 'Untitled Map')
 
     respond_to do |format|
       format.html do


### PR DESCRIPTION
map_scope already handles permissions, so we can remove the explicit filter on permission: 'private'