### PR TITLE
Some topics and synapses were hidden from users erroneously

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,6 +8,7 @@ engines:
     enabled: true
     config:
       languages:
+        count_threshold: 3 # rule of three
         ruby:
           mass_threshold: 36 # default: 18
         javascript:

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -38,10 +38,6 @@ class Map < ApplicationRecord
     topicmappings.or(synapsemappings)
   end
 
-  def mk_permission
-    Perm.short(permission)
-  end
-
   def contributors
     User.where(id: mappings.map(&:user_id).uniq)
   end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -34,6 +34,13 @@ class Map < ApplicationRecord
 
   after_save :update_deferring_topics_and_synapses, if: :permission_changed?
 
+  delegate :count, to: :topics, prefix: :topic # same as `def topic_count; topics.count; end`
+  delegate :count, to: :synapses, prefix: :synapse
+  delegate :count, to: :contributors, prefix: :contributor
+  delegate :count, to: :stars, prefix: :star
+
+  delegate :name, to: :user, prefix: true
+
   def mappings
     topicmappings.or(synapsemappings)
   end
@@ -46,26 +53,8 @@ class Map < ApplicationRecord
     User.where(id: user_id).or(User.where(id: collaborators))
   end
 
-  def topic_count
-    topics.length
-  end
-
-  def synapse_count
-    synapses.length
-  end
-
-  delegate :name, to: :user, prefix: true
-
   def user_image
     user.image.url(:thirtytwo)
-  end
-
-  def contributor_count
-    contributors.length
-  end
-
-  def star_count
-    stars.length
   end
 
   def collaborator_ids

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -32,6 +32,8 @@ class Map < ApplicationRecord
   # Validate the attached image is image/jpg, image/png, etc
   validates_attachment_content_type :screenshot, content_type: /\Aimage\/.*\Z/
 
+  after_save :update_deferring_topics_and_synapses, if: :permission_changed?
+
   def mappings
     topicmappings.or(synapsemappings)
   end
@@ -130,5 +132,10 @@ class Map < ApplicationRecord
       old_user_id
     end
     removed.compact
+  end
+
+  def update_deferring_topics_and_synapses
+    Topic.where(defer_to_map_id: id).update_all(permission: permission)
+    Synapse.where(defer_to_map_id: id).update_all(permission: permission)
   end
 end

--- a/app/models/synapse.rb
+++ b/app/models/synapse.rb
@@ -36,11 +36,7 @@ class Synapse < ApplicationRecord
     end
   end
 
-  def calculated_permission
-    defer_to_map&.permission || permission
-  end
-
   def as_json(_options = {})
-    super(methods: [:user_name, :user_image, :calculated_permission, :collaborator_ids])
+    super(methods: [:user_name, :user_image, :collaborator_ids])
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -128,9 +128,11 @@ class Topic < ApplicationRecord
   protected
 
   def create_metamap?
-    if link == '' and metacode.name == 'Metamap'
-      @map = Map.create({ name: name, permission: permission, desc: '', arranged: true, user_id: user_id })
-      self.link = Rails.application.routes.url_helpers.map_url(:host => ENV['MAILER_DEFAULT_URL'], :id => @map.id)
-    end
+    return unless (link == '') && (metacode.name == 'Metamap')
+
+    @map = Map.create(name: name, permission: permission, desc: '',
+                      arranged: true, user_id: user_id)
+    self.link = Rails.application.routes.url_helpers
+                     .map_url(host: ENV['MAILER_DEFAULT_URL'], id: @map.id)
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -125,15 +125,12 @@ class Topic < ApplicationRecord
     "Get: #{name}"
   end
 
-  def mk_permission
-    Perm.short(permission)
-  end
-
   protected
-    def create_metamap?
-      if link == '' and metacode.name == 'Metamap'
-        @map = Map.create({ name: name, permission: permission, desc: '', arranged: true, user_id: user_id })
-        self.link = Rails.application.routes.url_helpers.map_url(:host => ENV['MAILER_DEFAULT_URL'], :id => @map.id)
-      end
+
+  def create_metamap?
+    if link == '' and metacode.name == 'Metamap'
+      @map = Map.create({ name: name, permission: permission, desc: '', arranged: true, user_id: user_id })
+      self.link = Rails.application.routes.url_helpers.map_url(:host => ENV['MAILER_DEFAULT_URL'], :id => @map.id)
     end
+  end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -75,12 +75,8 @@ class Topic < ApplicationRecord
     Pundit.policy_scope(user, maps).map(&:id)
   end
 
-  def calculated_permission
-    defer_to_map&.permission || permission
-  end
-
   def as_json(options = {})
-    super(methods: [:user_name, :user_image, :calculated_permission, :collaborator_ids])
+    super(methods: [:user_name, :user_image, :collaborator_ids])
       .merge(inmaps: inmaps(options[:user]), inmapsLinks: inmapsLinks(options[:user]),
              map_count: map_count(options[:user]), synapse_count: synapse_count(options[:user]))
   end

--- a/app/policies/synapse_policy.rb
+++ b/app/policies/synapse_policy.rb
@@ -2,11 +2,10 @@
 class SynapsePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      visible = %w(public commons)
-      return scope.where(permission: visible) unless user
+      return scope.where(permission: %w(public commons)) unless user
 
-      scope.where(permission: visible)
-           .or(scope.where.not(defer_to_map_id: nil).where(defer_to_map_id: user.all_accessible_maps.map(&:id)))
+      scope.where(permission: %w(public commons))
+           .or(scope.where(defer_to_map_id: user.all_accessible_maps.map(&:id)))
            .or(scope.where(user_id: user.id))
     end
   end

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -2,11 +2,10 @@
 class TopicPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      visible = %w(public commons)
-      return scope.where(permission: visible) unless user
+      return scope.where(permission: %w(public commons)) unless user
 
-      scope.where(permission: visible)
-           .or(scope.where.not(defer_to_map_id: nil).where(defer_to_map_id: user.all_accessible_maps.map(&:id)))
+      scope.where(permission: %w(public commons))
+           .or(scope.where(defer_to_map_id: user.all_accessible_maps.map(&:id)))
            .or(scope.where(user_id: user.id))
     end
   end

--- a/frontend/src/Metamaps/DataModel/Synapse.js
+++ b/frontend/src/Metamaps/DataModel/Synapse.js
@@ -38,7 +38,6 @@ const Synapse = Backbone.Model.extend({
 
     newOptions.success = function(model, response, opt) {
       if (s) s(model, response, opt)
-      model.set('calculated_permission', model.get('permission'))
       model.trigger('saved')
 
       if (permBefore === 'private' && model.get('permission') !== 'private') {
@@ -85,7 +84,7 @@ const Synapse = Backbone.Model.extend({
       </li>`
   },
   authorizeToEdit: function(mapper) {
-    if (mapper && (this.get('calculated_permission') === 'commons' || this.get('collaborator_ids').includes(mapper.get('id')) || this.get('user_id') === mapper.get('id'))) return true
+    if (mapper && (this.get('permission') === 'commons' || this.get('collaborator_ids').includes(mapper.get('id')) || this.get('user_id') === mapper.get('id'))) return true
     else return false
   },
   authorizePermissionChange: function(mapper) {

--- a/frontend/src/Metamaps/DataModel/Topic.js
+++ b/frontend/src/Metamaps/DataModel/Topic.js
@@ -37,7 +37,6 @@ const Topic = Backbone.Model.extend({
 
     newOptions.success = function(model, response, opt) {
       if (s) s(model, response, opt)
-      model.set('calculated_permission', model.get('permission'))
       model.trigger('saved')
 
       if (permBefore === 'private' && model.get('permission') !== 'private') {
@@ -82,7 +81,7 @@ const Topic = Backbone.Model.extend({
   authorizeToEdit: function(mapper) {
     if (mapper &&
       (this.get('user_id') === mapper.get('id') ||
-      this.get('calculated_permission') === 'commons' ||
+      this.get('permission') === 'commons' ||
       this.get('collaborator_ids').includes(mapper.get('id')))) {
       return true
     } else {

--- a/frontend/src/Metamaps/Import.js
+++ b/frontend/src/Metamaps/Import.js
@@ -295,8 +295,7 @@ const Import = {
       permission: topicPermision,
       defer_to_map_id: deferToMapId,
       desc: desc || '',
-      link: link || '',
-      calculated_permission: Active.Map.get('permission')
+      link: link || ''
     })
     DataModel.Topics.add(topic)
 

--- a/frontend/src/Metamaps/SynapseCard.js
+++ b/frontend/src/Metamaps/SynapseCard.js
@@ -174,7 +174,7 @@ const SynapseCard = {
 
   add_perms_form: function(synapse) {
     // permissions - if owner, also allow permission editing
-    $('#editSynLowerBar').append('<div class="mapPerm ' + synapse.get('calculated_permission').substring(0, 2) + '"></div>')
+    $('#editSynLowerBar').append('<div class="mapPerm ' + synapse.get('permission').substring(0, 2) + '"></div>')
 
     // ability to change permission
     var selectingPermission = false

--- a/frontend/src/Metamaps/TopicCard.js
+++ b/frontend/src/Metamaps/TopicCard.js
@@ -448,8 +448,8 @@ const TopicCard = {
         nodeValues.inmaps += '<li class="hideExtra extraText"><a href="' + url + '">' + inmapsAr[i] + '</a></li>'
       }
     }
-    nodeValues.permission = topic.get('calculated_permission')
-    nodeValues.mk_permission = topic.get('calculated_permission').substring(0, 2)
+    nodeValues.permission = topic.get('permission')
+    nodeValues.mk_permission = topic.get('permission').substring(0, 2)
     nodeValues.map_count = topic.get('map_count').toString()
     nodeValues.synapse_count = topic.get('synapse_count').toString()
     nodeValues.id = topic.isNew() ? topic.cid : topic.id


### PR DESCRIPTION
This was happening because in the process of checking whether a user had access to a particular topic or synapse, we sometimes have to look at the permission of the map it is on, if the topic had a defer to map permission setting. We weren't doing this correctly. We were basing it off of whether a user had access to a map that was either
1. directly owned by them, or
2. shared explicitly with them. 
This does not include the common situation of a map being either public or commons, but not owned by them or shared with them, in which case they wouldn't be able to see the topic or synapse. 

confusing, we know. but the hope is that if we manage the complexity, the user experiences more simplicity. 

Our solution has been to update the database values of permissions on topics and synapses that "defer to map" when the map permission in question changes. This means we don't have to lookup the map in the topic or synapse policy scope functions to be able to know whether a certain user has access, we can just look at the topic or synapse record itself. This solution should scale