### PR TITLE
Track everything we need to reconstruct maps

### DIFF
--- a/app/controllers/api/v2/mappings_controller.rb
+++ b/app/controllers/api/v2/mappings_controller.rb
@@ -5,6 +5,21 @@ module Api
       def searchable_columns
         []
       end
+
+      def update
+        # mappings are the only things where the user is set to the latest updater
+        # done this way so that the model hooks can use the mapping user to determine who took this action
+        resource.user = current_user if current_user.present? # current_user should always be present
+        update_action
+        respond_with_resource
+      end
+
+      def destroy
+        # this is done so that the model hooks can use the mapping user to determine who took this action
+        resource.user = current_user if current_user.present? # current_user should always be present
+        destroy_action
+        head :no_content
+      end
     end
   end
 end

--- a/app/controllers/api/v2/mappings_controller.rb
+++ b/app/controllers/api/v2/mappings_controller.rb
@@ -6,19 +6,23 @@ module Api
         []
       end
 
+      def create
+        instantiate_resource
+        resource.user = current_user if current_user.present?
+        resource.updated_by = current_user if current_user.present?
+        authorize resource
+        create_action
+        respond_with_resource
+      end
+
       def update
-        # hack: set the user temporarily so the model hook can reference it, then set it back
-        temp = resource.user
-        resource.user = current_user
+        resource.updated_by = current_user if current_user.present?
         update_action
         respond_with_resource
-        resourse.user = temp
-        update_action
       end
 
       def destroy
-        # this is done so that the model hooks can use the mapping user to determine who took this action
-        resource.user = current_user if current_user.present? # current_user should always be present
+        resource.updated_by = current_user if current_user.present?
         destroy_action
         head :no_content
       end

--- a/app/controllers/api/v2/mappings_controller.rb
+++ b/app/controllers/api/v2/mappings_controller.rb
@@ -7,11 +7,13 @@ module Api
       end
 
       def update
-        # mappings are the only things where the user is set to the latest updater
-        # done this way so that the model hooks can use the mapping user to determine who took this action
-        resource.user = current_user if current_user.present? # current_user should always be present
+        # hack: set the user temporarily so the model hook can reference it, then set it back
+        temp = resource.user
+        resource.user = current_user
         update_action
         respond_with_resource
+        resourse.user = temp
+        update_action
       end
 
       def destroy

--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -31,6 +31,8 @@ class MappingsController < ApplicationController
   def update
     @mapping = Mapping.find(params[:id])
     authorize @mapping
+    # hack: set the user temporarily so that the model hook can reference it, and then set it back
+    temp = @mapping.user 
     @mapping.user = current_user
     @mapping.assign_attributes(mapping_params)
 
@@ -39,12 +41,16 @@ class MappingsController < ApplicationController
     else
       render json: @mapping.errors, status: :unprocessable_entity
     end
+    # restore the original mapping creator
+    @mapping.user = temp
+    @mapping.save
   end
 
   # DELETE /mappings/1.json
   def destroy
     @mapping = Mapping.find(params[:id])
     authorize @mapping
+    # hack: set the user temporarily so that the model hook can reference this user who is taking the action
     @mapping.user = current_user
     @mapping.destroy
 

--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -19,6 +19,7 @@ class MappingsController < ApplicationController
     @mapping = Mapping.new(mapping_params)
     authorize @mapping
     @mapping.user = current_user
+    @mapping.updated_by = current_user
 
     if @mapping.save
       render json: @mapping, status: :created
@@ -31,9 +32,7 @@ class MappingsController < ApplicationController
   def update
     @mapping = Mapping.find(params[:id])
     authorize @mapping
-    # hack: set the user temporarily so that the model hook can reference it, and then set it back
-    temp = @mapping.user 
-    @mapping.user = current_user
+    @mapping.updated_by = current_user
     @mapping.assign_attributes(mapping_params)
 
     if @mapping.save
@@ -41,17 +40,13 @@ class MappingsController < ApplicationController
     else
       render json: @mapping.errors, status: :unprocessable_entity
     end
-    # restore the original mapping creator
-    @mapping.user = temp
-    @mapping.save
   end
 
   # DELETE /mappings/1.json
   def destroy
     @mapping = Mapping.find(params[:id])
     authorize @mapping
-    # hack: set the user temporarily so that the model hook can reference this user who is taking the action
-    @mapping.user = current_user
+    @mapping.updated_by = current_user
     @mapping.destroy
 
     head :no_content

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,7 +2,8 @@
 class Event < ApplicationRecord
   KINDS = %w(user_present_on_map conversation_started_on_map 
                topic_added_to_map topic_moved_on_map topic_removed_from_map
-               synapse_added_to_map synapse_removed_from_map).freeze
+               synapse_added_to_map synapse_removed_from_map
+               topic_updated synapse_updated).freeze
 
   belongs_to :eventable, polymorphic: true
   belongs_to :map

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,6 @@ class Event < ApplicationRecord
                topic_added_to_map topic_moved_on_map topic_removed_from_map
                synapse_added_to_map synapse_removed_from_map).freeze
 
-  # has_many :notifications, dependent: :destroy
   belongs_to :eventable, polymorphic: true
   belongs_to :map
   belongs_to :user
@@ -16,18 +15,12 @@ class Event < ApplicationRecord
   validates :kind, inclusion: { in: KINDS }
   validates :eventable, presence: true
 
-  # def notify!(user)
-  #  notifications.create!(user: user)
-  # end
-
   def belongs_to?(this_user)
     user_id == this_user.id
   end
 
   def notify_webhooks!
-    # group = self.discussion.group
     map.webhooks.each { |webhook| WebhookService.publish! webhook: webhook, event: self }
-    # group.webhooks.each           { |webhook| WebhookService.publish! webhook: webhook, event: self }
   end
   handle_asynchronously :notify_webhooks!
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Event < ApplicationRecord
-  KINDS = %w(user_present_on_map conversation_started_on_map topic_added_to_map synapse_added_to_map).freeze
+  KINDS = %w(user_present_on_map conversation_started_on_map 
+               topic_added_to_map topic_moved_on_map topic_removed_from_map
+               synapse_added_to_map synapse_removed_from_map).freeze
 
   # has_many :notifications, dependent: :destroy
   belongs_to :eventable, polymorphic: true

--- a/app/models/events/synapse_added_to_map.rb
+++ b/app/models/events/synapse_added_to_map.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Events::SynapseAddedToMap < Event
+  # after_create :notify_users!
+
+  def self.publish!(mapping, user)
+    create!(kind: 'synapse_added_to_map',
+            eventable: mapping,
+            map: mapping.map,
+            user: user)
+  end
+end

--- a/app/models/events/synapse_added_to_map.rb
+++ b/app/models/events/synapse_added_to_map.rb
@@ -2,10 +2,11 @@
 class Events::SynapseAddedToMap < Event
   # after_create :notify_users!
 
-  def self.publish!(mapping, user)
+  def self.publish!(synapse, map, user, meta)
     create!(kind: 'synapse_added_to_map',
-            eventable: mapping,
-            map: mapping.map,
-            user: user)
+            eventable: synapse,
+            map: map,
+            user: user,
+            meta: meta)
   end
 end

--- a/app/models/events/synapse_removed_from_map.rb
+++ b/app/models/events/synapse_removed_from_map.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Events::SynapseRemovedFromMap < Event
+  # after_create :notify_users!
+
+  def self.publish!(mapping, user)
+    create!(kind: 'synapse_removed_from_map',
+            eventable: mapping,
+            map: mapping.map,
+            user: user)
+  end
+end

--- a/app/models/events/synapse_removed_from_map.rb
+++ b/app/models/events/synapse_removed_from_map.rb
@@ -2,10 +2,11 @@
 class Events::SynapseRemovedFromMap < Event
   # after_create :notify_users!
 
-  def self.publish!(synapse, map, user)
+  def self.publish!(synapse, map, user, meta)
     create!(kind: 'synapse_removed_from_map',
             eventable: synapse,
             map: map,
-            user: user)
+            user: user,
+            meta: meta)
   end
 end

--- a/app/models/events/synapse_removed_from_map.rb
+++ b/app/models/events/synapse_removed_from_map.rb
@@ -2,10 +2,10 @@
 class Events::SynapseRemovedFromMap < Event
   # after_create :notify_users!
 
-  def self.publish!(mapping, user)
+  def self.publish!(synapse, map, user)
     create!(kind: 'synapse_removed_from_map',
-            eventable: mapping,
-            map: mapping.map,
+            eventable: synapse,
+            map: map,
             user: user)
   end
 end

--- a/app/models/events/synapse_updated.rb
+++ b/app/models/events/synapse_updated.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Events::SynapseUpdated < Event
+  # after_create :notify_users!
+
+  def self.publish!(synapse, user, meta)
+    create!(kind: 'synapse_updated',
+            eventable: synapse,
+            user: user,
+            meta: meta)
+  end
+end

--- a/app/models/events/topic_added_to_map.rb
+++ b/app/models/events/topic_added_to_map.rb
@@ -2,10 +2,10 @@
 class Events::TopicAddedToMap < Event
   # after_create :notify_users!
 
-  def self.publish!(mapping, user, meta)
+  def self.publish!(topic, map, user, meta)
     create!(kind: 'topic_added_to_map',
-            eventable: mapping,
-            map: mapping.map,
+            eventable: topic,
+            map: map,
             user: user,
             meta: meta)
   end

--- a/app/models/events/topic_added_to_map.rb
+++ b/app/models/events/topic_added_to_map.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Events::TopicAddedToMap < Event
+  # after_create :notify_users!
+
+  def self.publish!(mapping, user, meta)
+    create!(kind: 'topic_added_to_map',
+            eventable: mapping,
+            map: mapping.map,
+            user: user,
+            meta: meta)
+  end
+end

--- a/app/models/events/topic_moved_on_map.rb
+++ b/app/models/events/topic_moved_on_map.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class Events::TopicMovedOnMap < Event
+  # after_create :notify_users!
+
+  def self.publish!(mapping, user, meta)
+    create!(kind: 'topic_moved_on_map',
+            eventable: mapping,
+            map: mapping.map,
+            user: user,
+            meta: meta)
+  end
+end

--- a/app/models/events/topic_moved_on_map.rb
+++ b/app/models/events/topic_moved_on_map.rb
@@ -2,10 +2,10 @@
 class Events::TopicMovedOnMap < Event
   # after_create :notify_users!
 
-  def self.publish!(mapping, user, meta)
+  def self.publish!(topic, map, user, meta)
     create!(kind: 'topic_moved_on_map',
-            eventable: mapping,
-            map: mapping.map,
+            eventable: topic,
+            map: map,
             user: user,
             meta: meta)
   end

--- a/app/models/events/topic_removed_from_map.rb
+++ b/app/models/events/topic_removed_from_map.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-class Events::NewMapping < Event
+class Events::TopicRemovedFromMap < Event
   # after_create :notify_users!
 
   def self.publish!(mapping, user)
-    create!(kind: mapping.mappable_type == 'Topic' ? 'topic_added_to_map' : 'synapse_added_to_map',
+    create!(kind: 'topic_removed_from_map',
             eventable: mapping,
             map: mapping.map,
             user: user)

--- a/app/models/events/topic_removed_from_map.rb
+++ b/app/models/events/topic_removed_from_map.rb
@@ -2,10 +2,11 @@
 class Events::TopicRemovedFromMap < Event
   # after_create :notify_users!
 
-  def self.publish!(topic, map, user)
+  def self.publish!(topic, map, user, meta)
     create!(kind: 'topic_removed_from_map',
             eventable: topic,
             map: map,
-            user: user)
+            user: user,
+            meta: meta)
   end
 end

--- a/app/models/events/topic_removed_from_map.rb
+++ b/app/models/events/topic_removed_from_map.rb
@@ -2,10 +2,10 @@
 class Events::TopicRemovedFromMap < Event
   # after_create :notify_users!
 
-  def self.publish!(mapping, user)
+  def self.publish!(topic, map, user)
     create!(kind: 'topic_removed_from_map',
-            eventable: mapping,
-            map: mapping.map,
+            eventable: topic,
+            map: map,
             user: user)
   end
 end

--- a/app/models/events/topic_updated.rb
+++ b/app/models/events/topic_updated.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Events::TopicUpdated < Event
+  # after_create :notify_users!
+
+  def self.publish!(topic, user, meta)
+    create!(kind: 'topic_updated',
+            eventable: topic,
+            user: user,
+            meta: meta)
+  end
+end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -16,11 +16,45 @@ class Mapping < ApplicationRecord
 
   delegate :name, to: :user, prefix: true
 
+  after_create :after_created
+  after_update :after_updated
+  before_destroy :before_destroyed
+
   def user_image
     user.image.url
   end
 
   def as_json(_options = {})
     super(methods: [:user_name, :user_image])
+  end
+
+  def after_created
+    if mappable_type == 'Topic'
+      meta = {'x': xloc, 'y': yloc}
+      Events::TopicAddedToMap.publish!(self, user, meta)
+    elsif mappable_type == 'Synapse'
+      Events::SynapseAddedToMap.publish!(self, user)
+    end
+  end
+
+  def after_updated
+    if mappable_type == 'Topic' and (xloc_changed? or yloc_changed?)
+      meta = {'x': xloc, 'y': yloc}
+      Events::TopicMovedOnMap.publish!(self, user, meta)
+    end
+  end
+
+  def before_destroyed
+    if mappable.defer_to_map
+      mappable.permission = mappable.defer_to_map.permission
+      mappable.defer_to_map_id = nil
+      mappable.save
+    end
+
+    if mappable_type == 'Topic'
+      Events::TopicRemovedFromMap.publish!(self, user)
+    elsif mappable_type == 'Synapse'
+      Events::SynapseRemovedFromMap.publish!(self, user)
+    end
   end
 end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -30,17 +30,17 @@ class Mapping < ApplicationRecord
 
   def after_created
     if mappable_type == 'Topic'
-      meta = {'x': xloc, 'y': yloc}
-      Events::TopicAddedToMap.publish!(self, user, meta)
+      meta = {'x': xloc, 'y': yloc, 'mapping_id': id}
+      Events::TopicAddedToMap.publish!(mappable, map, user, meta)
     elsif mappable_type == 'Synapse'
-      Events::SynapseAddedToMap.publish!(self, user)
+      Events::SynapseAddedToMap.publish!(mappable, map, user, meta)
     end
   end
 
   def after_updated
     if mappable_type == 'Topic' and (xloc_changed? or yloc_changed?)
-      meta = {'x': xloc, 'y': yloc}
-      Events::TopicMovedOnMap.publish!(self, user, meta)
+      meta = {'x': xloc, 'y': yloc, 'mapping_id': id}
+      Events::TopicMovedOnMap.publish!(mappable, map, user, meta)
     end
   end
 
@@ -51,10 +51,11 @@ class Mapping < ApplicationRecord
       mappable.save
     end
 
+    meta = {'mapping_id': id}
     if mappable_type == 'Topic'
-      Events::TopicRemovedFromMap.publish!(mappable, map, user)
+      Events::TopicRemovedFromMap.publish!(mappable, map, user, meta)
     elsif mappable_type == 'Synapse'
-      Events::SynapseRemovedFromMap.publish!(mappable, map, user)
+      Events::SynapseRemovedFromMap.publish!(mappable, map, user, meta)
     end
   end
 end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -6,6 +6,7 @@ class Mapping < ApplicationRecord
   belongs_to :mappable, polymorphic: true
   belongs_to :map, class_name: 'Map', foreign_key: 'map_id', touch: true
   belongs_to :user
+  belongs_to :updated_by, class_name: 'User'
 
   validates :xloc, presence: true,
                    unless: proc { |m| m.mappable_type == 'Synapse' }
@@ -40,7 +41,7 @@ class Mapping < ApplicationRecord
   def after_updated
     if mappable_type == 'Topic' and (xloc_changed? or yloc_changed?)
       meta = {'x': xloc, 'y': yloc, 'mapping_id': id}
-      Events::TopicMovedOnMap.publish!(mappable, map, user, meta)
+      Events::TopicMovedOnMap.publish!(mappable, map, updated_by, meta)
     end
   end
 
@@ -53,9 +54,9 @@ class Mapping < ApplicationRecord
 
     meta = {'mapping_id': id}
     if mappable_type == 'Topic'
-      Events::TopicRemovedFromMap.publish!(mappable, map, user, meta)
+      Events::TopicRemovedFromMap.publish!(mappable, map, updated_by, meta)
     elsif mappable_type == 'Synapse'
-      Events::SynapseRemovedFromMap.publish!(mappable, map, user, meta)
+      Events::SynapseRemovedFromMap.publish!(mappable, map, updated_by, meta)
     end
   end
 end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -52,9 +52,9 @@ class Mapping < ApplicationRecord
     end
 
     if mappable_type == 'Topic'
-      Events::TopicRemovedFromMap.publish!(self, user)
+      Events::TopicRemovedFromMap.publish!(mappable, map, user)
     elsif mappable_type == 'Synapse'
-      Events::SynapseRemovedFromMap.publish!(self, user)
+      Events::SynapseRemovedFromMap.publish!(mappable, map, user)
     end
   end
 end

--- a/app/models/synapse.rb
+++ b/app/models/synapse.rb
@@ -48,6 +48,7 @@ class Synapse < ApplicationRecord
       new = self.attributes.select {|k,v| attrs.include?(k) } 
       old = changed_attributes.select {|k,v| attrs.include?(k) } 
       meta = new.merge(old) # we are prioritizing the old values, keeping them 
+      meta['changed'] = changed_attributes.keys.select {|k| attrs.include?(k) } 
       Events::SynapseUpdated.publish!(self, user, meta)
     end
   end

--- a/app/models/synapse.rb
+++ b/app/models/synapse.rb
@@ -22,6 +22,8 @@ class Synapse < ApplicationRecord
     where(topic1_id: topic_id).or(where(topic2_id: topic_id))
   }
 
+  after_update :after_updated
+
   delegate :name, to: :user, prefix: true
 
   def user_image
@@ -38,5 +40,15 @@ class Synapse < ApplicationRecord
 
   def as_json(_options = {})
     super(methods: [:user_name, :user_image, :collaborator_ids])
+  end
+
+  def after_updated
+    attrs = ['desc', 'category', 'permission', 'defer_to_map_id']
+    if attrs.any? {|k| changed_attributes.key?(k)}
+      new = self.attributes.select {|k,v| attrs.include?(k) } 
+      old = changed_attributes.select {|k,v| attrs.include?(k) } 
+      meta = new.merge(old) # we are prioritizing the old values, keeping them 
+      Events::SynapseUpdated.publish!(self, user, meta)
+    end
   end
 end

--- a/app/models/synapse.rb
+++ b/app/models/synapse.rb
@@ -45,10 +45,10 @@ class Synapse < ApplicationRecord
   def after_updated
     attrs = ['desc', 'category', 'permission', 'defer_to_map_id']
     if attrs.any? {|k| changed_attributes.key?(k)}
-      new = self.attributes.select {|k,v| attrs.include?(k) } 
-      old = changed_attributes.select {|k,v| attrs.include?(k) } 
+      new = self.attributes.select {|k| attrs.include?(k) }
+      old = changed_attributes.select {|k| attrs.include?(k) }
       meta = new.merge(old) # we are prioritizing the old values, keeping them 
-      meta['changed'] = changed_attributes.keys.select {|k| attrs.include?(k) } 
+      meta['changed'] = changed_attributes.keys.select {|k| attrs.include?(k) }
       Events::SynapseUpdated.publish!(self, user, meta)
     end
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -140,10 +140,10 @@ class Topic < ApplicationRecord
   def after_updated
     attrs = ['name', 'desc', 'link', 'metacode_id', 'permission', 'defer_to_map_id']
     if attrs.any? {|k| changed_attributes.key?(k)}
-      new = self.attributes.select {|k,v| attrs.include?(k) } 
-      old = changed_attributes.select {|k,v| attrs.include?(k) } 
+      new = self.attributes.select {|k| attrs.include?(k) }
+      old = changed_attributes.select {|k| attrs.include?(k) }
       meta = new.merge(old) # we are prioritizing the old values, keeping them 
-      meta['changed'] = changed_attributes.keys.select {|k| attrs.include?(k) } 
+      meta['changed'] = changed_attributes.keys.select {|k| attrs.include?(k) }
       Events::TopicUpdated.publish!(self, user, meta)
     end
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -143,6 +143,7 @@ class Topic < ApplicationRecord
       new = self.attributes.select {|k,v| attrs.include?(k) } 
       old = changed_attributes.select {|k,v| attrs.include?(k) } 
       meta = new.merge(old) # we are prioritizing the old values, keeping them 
+      meta['changed'] = changed_attributes.keys.select {|k| attrs.include?(k) } 
       Events::TopicUpdated.publish!(self, user, meta)
     end
   end

--- a/app/models/webhooks/slack/base.rb
+++ b/app/models/webhooks/slack/base.rb
@@ -16,44 +16,13 @@ Webhooks::Slack::Base = Struct.new(:webhook, :event) do
 
   delegate :channel, to: :webhook
 
-  def attachments
-    [{
-      title:       attachment_title,
-      text:        attachment_text,
-      fields:      attachment_fields,
-      fallback:    attachment_fallback
-    }]
-  end
-
   alias_method :read_attribute_for_serialization, :send
 
   private
 
-  # def motion_vote_field
-  #  {
-  #    title: "Vote on this proposal",
-  #    value: "#{proposal_link(eventable, "yes")} · " +
-  #           "#{proposal_link(eventable, "abstain")} · " +
-  #           "#{proposal_link(eventable, "no")} · " +
-  #           "#{proposal_link(eventable, "block")}"
-  #  }
-  # end
-
   def view_map_on_metamaps(text = nil)
     "<#{map_url(event.map)}|#{text || event.map.name}>"
   end
-
-  # def view_discussion_on_loomio(params = {})
-  #  { value: discussion_link(I18n.t(:"webhooks.slack.view_it_on_loomio"), params) }
-  # end
-
-  # def proposal_link(proposal, position = nil)
-  #  discussion_link position || proposal.name, { proposal: proposal.key, position: position }
-  # end
-
-  # def discussion_link(text = nil, params = {})
-  #  "<#{discussion_url(eventable.map, params)}|#{text || eventable.discussion.title}>"
-  # end
 
   def eventable
     @eventable ||= event.eventable
@@ -63,12 +32,3 @@ Webhooks::Slack::Base = Struct.new(:webhook, :event) do
     @author ||= eventable.author
   end
 end
-
-# webhooks:
-#    slack:
-#      motion_closed: "*%{name}* has closed"
-#      motion_closing_soon: "*%{name}* has a proposal closing in 24 hours"
-#      motion_outcome_created: "*%{author}* published an outcome in *%{name}*"
-#      motion_outcome_updated: "*%{author}* updated the outcome for *%{name}*"
-#      new_motion: "*%{author}* started a new proposal in *%{name}*"
-#      view_it_on_loomio: "View it on Loomio"

--- a/app/models/webhooks/slack/conversation_started_on_map.rb
+++ b/app/models/webhooks/slack/conversation_started_on_map.rb
@@ -3,24 +3,4 @@ class Webhooks::Slack::ConversationStartedOnMap < Webhooks::Slack::Base
   def text
     "There is a live conversation starting on map *#{event.map.name}*. #{view_map_on_metamaps('Join in!')}"
   end
-  # TODO: it would be sweet if it sends it with the metacode as the icon_url
-
-  def attachment_fallback
-    '' # {}"*#{eventable.name}*\n#{eventable.description}\n"
-  end
-
-  def attachment_title
-    '' # proposal_link(eventable)
-  end
-
-  def attachment_text
-    '' # "#{eventable.description}\n"
-  end
-
-  def attachment_fields
-    [{
-      title: 'nothing',
-      value: 'nothing'
-    }] # [motion_vote_field]
-  end
 end

--- a/app/models/webhooks/slack/synapse_added_to_map.rb
+++ b/app/models/webhooks/slack/synapse_added_to_map.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Webhooks::Slack::SynapseAddedToMap < Webhooks::Slack::Base
   def text
-    connector = eventable.mappable.desc.empty? ? '->' : eventable.mappable.desc
-    "\"*#{eventable.mappable.topic1.name}* #{connector} *#{eventable.mappable.topic2.name}*\" was added as a connection by *#{event.user.name}* to the map *#{view_map_on_metamaps}*"
+    connector = eventable.desc.empty? ? '->' : eventable.desc
+    "\"*#{eventable.topic1.name}* #{connector} *#{eventable.topic2.name}*\" was added as a connection by *#{event.user.name}* to the map *#{view_map_on_metamaps}*"
   end
 end

--- a/app/models/webhooks/slack/synapse_added_to_map.rb
+++ b/app/models/webhooks/slack/synapse_added_to_map.rb
@@ -1,25 +1,7 @@
 # frozen_string_literal: true
 class Webhooks::Slack::SynapseAddedToMap < Webhooks::Slack::Base
   def text
-    "\"*#{eventable.mappable.topic1.name}* #{eventable.mappable.desc || '->'} *#{eventable.mappable.topic2.name}*\" was added as a connection to the map *#{view_map_on_metamaps}*"
-  end
-
-  def attachment_fallback
-    '' # {}"*#{eventable.name}*\n#{eventable.description}\n"
-  end
-
-  def attachment_title
-    '' # proposal_link(eventable)
-  end
-
-  def attachment_text
-    '' # "#{eventable.description}\n"
-  end
-
-  def attachment_fields
-    [{
-      title: 'nothing',
-      value: 'nothing'
-    }] # [motion_vote_field]
+    connector = eventable.mappable.desc.empty? ? '->' : eventable.mappable.desc
+    "\"*#{eventable.mappable.topic1.name}* #{connector} *#{eventable.mappable.topic2.name}*\" was added as a connection by *#{event.user.name}* to the map *#{view_map_on_metamaps}*"
   end
 end

--- a/app/models/webhooks/slack/synapse_removed_from_map.rb
+++ b/app/models/webhooks/slack/synapse_removed_from_map.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class Webhooks::Slack::SynapseRemovedFromMap < Webhooks::Slack::Base
+  def text
+    connector = eventable.desc.empty? ? '->' : eventable.desc
+    # todo express correct directionality of arrows when desc is empty
+    "\"*#{eventable.topic1.name}* #{connector} *#{eventable.topic2.name}*\" was removed by *#{event.user.name}* as a connection from the map *#{view_map_on_metamaps}*"
+  end
+end

--- a/app/models/webhooks/slack/topic_added_to_map.rb
+++ b/app/models/webhooks/slack/topic_added_to_map.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Webhooks::Slack::TopicAddedToMap < Webhooks::Slack::Base
   def text
-    "*#{eventable.mappable.name}* was added by *#{event.user.name}* to the map *#{view_map_on_metamaps}*"
+    "*#{eventable.name}* was added by *#{event.user.name}* to the map *#{view_map_on_metamaps}*"
   end
   # TODO: it would be sweet if it sends it with the metacode as the icon_url
 end

--- a/app/models/webhooks/slack/topic_added_to_map.rb
+++ b/app/models/webhooks/slack/topic_added_to_map.rb
@@ -1,26 +1,7 @@
 # frozen_string_literal: true
 class Webhooks::Slack::TopicAddedToMap < Webhooks::Slack::Base
   def text
-    "New #{eventable.mappable.metacode.name} topic *#{eventable.mappable.name}* was added to the map *#{view_map_on_metamaps}*"
+    "*#{eventable.mappable.name}* was added by *#{event.user.name}* to the map *#{view_map_on_metamaps}*"
   end
   # TODO: it would be sweet if it sends it with the metacode as the icon_url
-
-  def attachment_fallback
-    '' # {}"*#{eventable.name}*\n#{eventable.description}\n"
-  end
-
-  def attachment_title
-    '' # proposal_link(eventable)
-  end
-
-  def attachment_text
-    '' # "#{eventable.description}\n"
-  end
-
-  def attachment_fields
-    [{
-      title: 'nothing',
-      value: 'nothing'
-    }] # [motion_vote_field]
-  end
 end

--- a/app/models/webhooks/slack/topic_moved_on_map.rb
+++ b/app/models/webhooks/slack/topic_moved_on_map.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Webhooks::Slack::TopicMovedOnMap < Webhooks::Slack::Base
+  def text
+    "*#{eventable.mappable.name}* was moved by *#{event.user.name}* on the map *#{view_map_on_metamaps}*"
+  end
+end

--- a/app/models/webhooks/slack/topic_moved_on_map.rb
+++ b/app/models/webhooks/slack/topic_moved_on_map.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Webhooks::Slack::TopicMovedOnMap < Webhooks::Slack::Base
   def text
-    "*#{eventable.mappable.name}* was moved by *#{event.user.name}* on the map *#{view_map_on_metamaps}*"
+    "*#{eventable.name}* was moved by *#{event.user.name}* on the map *#{view_map_on_metamaps}*"
   end
 end

--- a/app/models/webhooks/slack/topic_removed_from_map.rb
+++ b/app/models/webhooks/slack/topic_removed_from_map.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Webhooks::Slack::TopicRemovedFromMap < Webhooks::Slack::Base
+  def text
+    "*#{eventable.name}* was removed by *#{event.user.name}* from the map *#{view_map_on_metamaps}*"
+  end
+end

--- a/app/models/webhooks/slack/user_present_on_map.rb
+++ b/app/models/webhooks/slack/user_present_on_map.rb
@@ -3,24 +3,4 @@ class Webhooks::Slack::UserPresentOnMap < Webhooks::Slack::Base
   def text
     "Mapper *#{event.user.name}* has joined the map *#{event.map.name}*. #{view_map_on_metamaps('Map with them')}"
   end
-  # TODO: it would be sweet if it sends it with the metacode as the icon_url
-
-  def attachment_fallback
-    '' # {}"*#{eventable.name}*\n#{eventable.description}\n"
-  end
-
-  def attachment_title
-    '' # proposal_link(eventable)
-  end
-
-  def attachment_text
-    '' # "#{eventable.description}\n"
-  end
-
-  def attachment_fields
-    [{
-      title: 'nothing',
-      value: 'nothing'
-    }] # [motion_vote_field]
-  end
 end

--- a/app/serializers/api/v2/mapping_serializer.rb
+++ b/app/serializers/api/v2/mapping_serializer.rb
@@ -14,6 +14,7 @@ module Api
       def self.embeddable
         {
           user: {},
+          updated_by: {},
           map: {}
         }
       end

--- a/app/serializers/webhook_serializer.rb
+++ b/app/serializers/webhook_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class WebhookSerializer < ActiveModel::Serializer
-  attributes :text, :username, :icon_url # , :attachments
+  attributes :text, :username, :icon_url
   attribute :channel, if: :has_channel?
 
   def has_channel?

--- a/db/migrate/20161214140124_add_meta_to_events.rb
+++ b/db/migrate/20161214140124_add_meta_to_events.rb
@@ -1,0 +1,5 @@
+class AddMetaToEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :meta, :json
+  end
+end

--- a/db/migrate/20161216174257_add_updated_by_to_mappings.rb
+++ b/db/migrate/20161216174257_add_updated_by_to_mappings.rb
@@ -1,0 +1,5 @@
+class AddUpdatedByToMappings < ActiveRecord::Migration[5.0]
+  def change
+      add_reference :mappings, :updated_by, foreign_key: {to_table: :users}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161125175229) do
+ActiveRecord::Schema.define(version: 20161216174257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20161125175229) do
     t.integer  "map_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.json     "meta"
     t.index ["eventable_type", "eventable_id"], name: "index_events_on_eventable_type_and_eventable_id", using: :btree
     t.index ["map_id"], name: "index_events_on_map_id", using: :btree
     t.index ["user_id"], name: "index_events_on_user_id", using: :btree
@@ -128,10 +129,12 @@ ActiveRecord::Schema.define(version: 20161125175229) do
     t.datetime "updated_at",    null: false
     t.integer  "mappable_id"
     t.string   "mappable_type"
+    t.integer  "updated_by_id"
     t.index ["map_id", "synapse_id"], name: "index_mappings_on_map_id_and_synapse_id", using: :btree
     t.index ["map_id", "topic_id"], name: "index_mappings_on_map_id_and_topic_id", using: :btree
     t.index ["map_id"], name: "index_mappings_on_map_id", using: :btree
     t.index ["mappable_id", "mappable_type"], name: "index_mappings_on_mappable_id_and_mappable_type", using: :btree
+    t.index ["updated_by_id"], name: "index_mappings_on_updated_by_id", using: :btree
     t.index ["user_id"], name: "index_mappings_on_user_id", using: :btree
   end
 
@@ -336,5 +339,6 @@ ActiveRecord::Schema.define(version: 20161125175229) do
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "mappings", "users", column: "updated_by_id"
   add_foreign_key "tokens", "users"
 end

--- a/doc/api/apis/mappings.raml
+++ b/doc/api/apis/mappings.raml
@@ -1,6 +1,6 @@
 #type: collection
 get:
-  is: [ embeddable: { embedFields: "user,map" }, orderable, pageable ]
+  is: [ embeddable: { embedFields: "user,updated_by,map" }, orderable, pageable ]
   securedBy: [ null, token, oauth_2_0, cookie ]
   responses:
     200:
@@ -31,7 +31,7 @@ post:
 /{id}:
   #type: item
   get:
-    is: [ embeddable: { embedFields: "user,map" } ]
+    is: [ embeddable: { embedFields: "user,updated_by,map" } ]
     securedBy: [ null, token, oauth_2_0, cookie ]
     responses:
       200:

--- a/doc/api/examples/mapping.json
+++ b/doc/api/examples/mapping.json
@@ -6,6 +6,7 @@
     "mappable_id": 1,
     "mappable_type": "Synapse",
     "user_id": 1,
+    "updated_by_id": 1,
     "map_id": 1
   }
 }

--- a/doc/api/examples/mappings.json
+++ b/doc/api/examples/mappings.json
@@ -8,6 +8,7 @@
       "mappable_type": "Topic",
       "updated_at": "2016-03-25T08:44:07.152Z",
       "user_id": 1,
+      "updated_by_id": 1,
       "xloc": -271,
       "yloc": 22
     },
@@ -19,6 +20,7 @@
       "mappable_type": "Topic",
       "updated_at": "2016-03-25T08:44:13.907Z",
       "user_id": 1,
+      "updated_by_id": 1,
       "xloc": -12,
       "yloc": 61
     },
@@ -30,6 +32,7 @@
       "mappable_type": "Topic",
       "updated_at": "2016-03-25T08:44:19.333Z",
       "user_id": 1,
+      "updated_by_id": 1,
       "xloc": -93,
       "yloc": -90
     },
@@ -40,7 +43,8 @@
       "mappable_id": 1,
       "mappable_type": "Synapse",
       "updated_at": "2016-03-25T08:44:21.337Z",
-      "user_id": 1
+      "user_id": 1,
+      "updated_by_id": 1
     }
   ],
   "page": {

--- a/doc/api/schemas/_mapping.json
+++ b/doc/api/schemas/_mapping.json
@@ -35,6 +35,12 @@
     },
     "user": {
       "$ref": "_user.json"
+    },
+    "updated_by_id": {
+      "$ref": "_id.json"
+    },
+    "updated_by": {
+      "$ref": "_user.json"
     }
   },
   "required": [
@@ -55,6 +61,12 @@
       "oneOf": [
         { "required": [ "user_id" ] },
         { "required": [ "user" ] }
+      ]
+    },
+    {
+      "oneOf": [
+        { "required": [ "updated_by_id" ] },
+        { "required": [ "updated_by" ] }
       ]
     }
   ]


### PR DESCRIPTION
An important thing to note here is how it is captured with every event who the 'actor' was. 

Assuming that these changes make it in, the most glaring set of metadata we would not be logging are the edit history of topics and synapses. As it stands, every time someone makes a change to those values, we lose the old values. If we started to also capture those values, possibly also as `events`, then we would truly be able to reconstruct the lifecycle of a map, by merging the event streams of the map, with the event streams of the topics and synapses that were present on it at the time