### PR TITLE
re-implement chat in react

### DIFF
--- a/app/assets/stylesheets/junto.css.erb
+++ b/app/assets/stylesheets/junto.css.erb
@@ -90,13 +90,16 @@
   left: 30px;
   top: 72px;
 }
+#chat-box-wrapper {
+  height: 100%;
+  float: right;
+}
 .chat-box {
   position: relative;
   display: flex;
   flex-direction: column;
   z-index: 1;
   width: 300px;
-  float: right;
   height: 100%;
   background: #424242;
   box-shadow: -8px 0px 16px 2px rgba(0, 0, 0, 0.23);

--- a/app/assets/stylesheets/junto.css.erb
+++ b/app/assets/stylesheets/junto.css.erb
@@ -223,8 +223,8 @@
   float: right;
   background: #4FC059 url(<%= asset_path 'invitepeer16.png' %>) no-repeat center center;
 }
-.chat-box .participants .participant.pending .chat-participant-invite-call,
-.chat-box .participants .participant.pending .chat-participant-invite-join {
+.chat-box .participants .participant .chat-participant-invite-call.pending,
+.chat-box .participants .participant .chat-participant-invite-join.pending {
     background: #dab539 url(<%= asset_path 'ellipsis.gif' %>) no-repeat center center;
 }
 .chat-box .participants .participant .chat-participant-participating {

--- a/app/assets/stylesheets/junto.css.erb
+++ b/app/assets/stylesheets/junto.css.erb
@@ -117,7 +117,6 @@
   background: url(<%= asset_path 'junto_spinner_dark.gif' %>) no-repeat 2px 8px, url(<%= asset_path 'tray_tab.png' %>) no-repeat !important;
 }
 .chat-box .chat-button .chat-unread {
-  display: none;
   background: #DAB539;
   position: absolute;
   top: -3px;

--- a/app/assets/stylesheets/junto.css.erb
+++ b/app/assets/stylesheets/junto.css.erb
@@ -178,7 +178,6 @@
   overflow-y: auto;
 }
 .chat-box .participants .conversation-live {
-  display: none;
   padding: 5px 10px 5px 10px;
   background: #c04f4f;
   margin: 5px 10px;
@@ -188,15 +187,6 @@
   float: right;
   cursor: pointer;
   color: #EBFF00;
-}
-.chat-box .participants .conversation-live .leave {
-  display: none;
-}
-.chat-box .participants.is-participating .conversation-live .leave {
-  display: block;
-}
-.chat-box .participants.is-participating .conversation-live .join {
-  display: none;
 }
 .chat-box .participants .participant {
   width: 89%;
@@ -227,19 +217,6 @@
   padding: 2px 8px 0;
   text-align: left;
 }
-.chat-box .participants .participant.is-self .chat-participant-invite-call,
-.chat-box .participants .participant.is-self .chat-participant-invite-join {
-  display: none !important;
-}
-.chat-box .participants.is-live .participant .chat-participant-invite-call {
-  display: none;
-}
-.chat-box .participants .participant .chat-participant-invite-join {
-  display: none;
-}
-.chat-box .participants.is-live.is-participating .participant:not(.active) .chat-participant-invite-join {
-  display: block;
-}
 .chat-box .participants .participant .chat-participant-invite-call,
 .chat-box .participants .participant .chat-participant-invite-join
  {
@@ -252,7 +229,6 @@
 }
 .chat-box .participants .participant .chat-participant-participating {
   float: right;
-  display: none;
   margin-top: 14px;
 }
 .chat-box .participants .participant .chat-participant-participating .green-dot {
@@ -260,9 +236,6 @@
   width: 12px;
   height: 12px;
   border-radius: 6px;
-}
-.chat-box .participants .participant.active .chat-participant-participating {
-  display: block;
 }
 .chat-box .chat-header {
   width: 276px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
 
 <body class="<%= authenticated? ? "authenticated" : "unauthenticated" %> controller-<%= controller_name %> action-<%= action_name %>">
 
+    <div id="chat-box-wrapper"></div>
+
     <a class='feedback-icon' target='_blank' href='https://hylo.com/c/metamaps'></a>    
 
     <%= content_tag :div, class: "main" do %>

--- a/frontend/src/Metamaps/Realtime/index.js
+++ b/frontend/src/Metamaps/Realtime/index.js
@@ -174,8 +174,6 @@ let Realtime = {
       self.room = new Views.Room({
         webrtc: self.webrtc,
         socket: self.socket,
-        username: Active.Mapper ? Active.Mapper.get('name') : '',
-        image: Active.Mapper ? Active.Mapper.get('image') : '',
         room: 'global',
         $video: self.localVideo.$video,
         myVideoView: self.localVideo.view,
@@ -187,26 +185,26 @@ let Realtime = {
   addJuntoListeners: function() {
     var self = Realtime
 
-    $(document).on(Views.ChatView.events.openTray, function() {
+    $(document).on(ChatView.events.openTray, function() {
       $('.main').addClass('compressed')
       self.chatOpen = true
       self.positionPeerIcons()
     })
-    $(document).on(Views.ChatView.events.closeTray, function() {
+    $(document).on(ChatView.events.closeTray, function() {
       $('.main').removeClass('compressed')
       self.chatOpen = false
       self.positionPeerIcons()
     })
-    $(document).on(Views.ChatView.events.videosOn, function() {
+    $(document).on(ChatView.events.videosOn, function() {
       $('#wrapper').removeClass('hideVideos')
     })
-    $(document).on(Views.ChatView.events.videosOff, function() {
+    $(document).on(ChatView.events.videosOff, function() {
       $('#wrapper').addClass('hideVideos')
     })
-    $(document).on(Views.ChatView.events.cursorsOn, function() {
+    $(document).on(ChatView.events.cursorsOn, function() {
       $('#wrapper').removeClass('hideCursors')
     })
-    $(document).on(Views.ChatView.events.cursorsOff, function() {
+    $(document).on(ChatView.events.cursorsOff, function() {
       $('#wrapper').addClass('hideCursors')
     })
   },
@@ -218,7 +216,7 @@ let Realtime = {
         self.setupSocket()
         self.setupLocalSendables()
       }
-      self.room.addMessages(new DataModel.MessageCollection(DataModel.Messages), true)
+      self.setupChat() // chat can happen on public maps too
     }
   },
   endActiveMap: function() {
@@ -228,16 +226,14 @@ let Realtime = {
     if (self.inConversation) self.leaveCall()
     self.leaveMap()
     $('.collabCompass').remove()
-    if (self.room) {
-      self.room.leave()
-      ChatView.hide()
-      ChatView.close()
-    }
+    if (self.room) self.room.leave()
+    ChatView.hide()
+    ChatView.close()
+    ChatView.reset()
   },
   turnOn: function(notify) {
     var self = Realtime
     $('.collabCompass').show()
-    ChatView.show()
     self.room.room = 'map-' + Active.Map.id
     self.activeMapper = {
       id: Active.Mapper.id,
@@ -250,7 +246,13 @@ let Realtime = {
     self.localVideo.view.$container.find('.video-cutoff').css({
       border: '4px solid ' + self.activeMapper.color
     })
+  },
+  setupChat: function() {
+    const self = Realtime
+    ChatView.setNewMap(self.room.room)
     ChatView.addParticipant(self.activeMapper)
+    ChatView.addMessages(new DataModel.MessageCollection(DataModel.Messages), true)
+    ChatView.show()
   },
   setupSocket: function() {
     var self = Realtime
@@ -324,7 +326,7 @@ let Realtime = {
     var createMessage = function(event, data) {
       self.createMessage(data)
     }
-    $(document).on(Views.Room.events.newMessage + '.map', createMessage)
+    $(document).on(ChatView.events.newMessage + '.map', createMessage)
   },
   countOthersInConversation: function() {
     var self = Realtime
@@ -395,7 +397,7 @@ let Realtime = {
   callEnded: function() {
     var self = Realtime
 
-    self.room.conversationEnding()
+    ChatView.conversationEnded()
     self.room.leaveVideoOnly()
     self.inConversation = false
     self.localVideo.view.$container.hide().css({

--- a/frontend/src/Metamaps/Realtime/index.js
+++ b/frontend/src/Metamaps/Realtime/index.js
@@ -186,11 +186,10 @@ let Realtime = {
       })
       self.room.videoAdded(self.handleVideoAdded)
 
-      if (!Active.Map) {
-        self.room.chat.$container.hide()
+      if (Active.Map) {
+        self.room.chat.addWrapper()
+        self.room.chat.render()
       }
-      self.room.chat.addWrapper()
-      self.room.chat.render()
     } // if Active.Mapper
   },
   addJuntoListeners: function() {
@@ -239,14 +238,14 @@ let Realtime = {
     $('.collabCompass').remove()
     if (self.room) {
       self.room.leave()
-      self.room.chat.$container.hide()
+      self.room.chat.hide()
       self.room.chat.close()
     }
   },
   turnOn: function(notify) {
     var self = Realtime
     $('.collabCompass').show()
-    self.room.chat.$container.show()
+    self.room.chat.show()
     self.room.room = 'map-' + Active.Map.id
     self.activeMapper = {
       id: Active.Mapper.id,

--- a/frontend/src/Metamaps/Realtime/index.js
+++ b/frontend/src/Metamaps/Realtime/index.js
@@ -249,7 +249,7 @@ let Realtime = {
   },
   setupChat: function() {
     const self = Realtime
-    ChatView.setNewMap(self.room.room)
+    ChatView.setNewMap()
     ChatView.addParticipant(self.activeMapper)
     ChatView.addMessages(new DataModel.MessageCollection(DataModel.Messages), true)
     ChatView.show()

--- a/frontend/src/Metamaps/Realtime/index.js
+++ b/frontend/src/Metamaps/Realtime/index.js
@@ -187,7 +187,6 @@ let Realtime = {
       self.room.videoAdded(self.handleVideoAdded)
 
       if (Active.Map) {
-        self.room.chat.addWrapper()
         self.room.chat.render()
       }
     } // if Active.Mapper

--- a/frontend/src/Metamaps/Realtime/index.js
+++ b/frontend/src/Metamaps/Realtime/index.js
@@ -8,6 +8,7 @@ import DataModel from '../DataModel'
 import JIT from '../JIT'
 import Util from '../Util'
 import Views from '../Views'
+import { ChatView } from '../Views'
 import Visualize from '../Visualize'
 
 import {
@@ -178,17 +179,9 @@ let Realtime = {
         room: 'global',
         $video: self.localVideo.$video,
         myVideoView: self.localVideo.view,
-        config: { DOUBLE_CLICK_TOLERANCE: 200 },
-        soundUrls: [
-          serverData['sounds/MM_sounds.mp3'],
-          serverData['sounds/MM_sounds.ogg']
-        ]
+        config: { DOUBLE_CLICK_TOLERANCE: 200 }
       })
       self.room.videoAdded(self.handleVideoAdded)
-
-      if (Active.Map) {
-        self.room.chat.render()
-      }
     } // if Active.Mapper
   },
   addJuntoListeners: function() {
@@ -237,14 +230,14 @@ let Realtime = {
     $('.collabCompass').remove()
     if (self.room) {
       self.room.leave()
-      self.room.chat.hide()
-      self.room.chat.close()
+      ChatView.hide()
+      ChatView.close()
     }
   },
   turnOn: function(notify) {
     var self = Realtime
     $('.collabCompass').show()
-    self.room.chat.show()
+    ChatView.show()
     self.room.room = 'map-' + Active.Map.id
     self.activeMapper = {
       id: Active.Mapper.id,
@@ -257,7 +250,7 @@ let Realtime = {
     self.localVideo.view.$container.find('.video-cutoff').css({
       border: '4px solid ' + self.activeMapper.color
     })
-    self.room.chat.addParticipant(self.activeMapper)
+    ChatView.addParticipant(self.activeMapper)
   },
   setupSocket: function() {
     var self = Realtime

--- a/frontend/src/Metamaps/Realtime/index.js
+++ b/frontend/src/Metamaps/Realtime/index.js
@@ -189,7 +189,8 @@ let Realtime = {
       if (!Active.Map) {
         self.room.chat.$container.hide()
       }
-      $('body').prepend(self.room.chat.$container)
+      self.room.chat.addWrapper()
+      self.room.chat.render()
     } // if Active.Mapper
   },
   addJuntoListeners: function() {

--- a/frontend/src/Metamaps/Realtime/receivable.js
+++ b/frontend/src/Metamaps/Realtime/receivable.js
@@ -234,7 +234,7 @@ export const lostMapper = self => data => {
   ChatView.sound.play('leavemap')
   // $('#mapper' + data.userid).remove()
   $('#compass' + data.userid).remove()
-  ChatView.removeParticipant(data.username)
+  ChatView.removeParticipant(ChatView.participants.findWhere({id: data.userid}))
 
   GlobalUI.notifyUser(data.username + ' just left the map')
 

--- a/frontend/src/Metamaps/Realtime/receivable.js
+++ b/frontend/src/Metamaps/Realtime/receivable.js
@@ -9,6 +9,7 @@ import { indexOf } from 'lodash'
 import { JUNTO_UPDATED } from './events'
 
 import Active from '../Active'
+import { ChatView } from '../Views'
 import DataModel from '../DataModel'
 import GlobalUI from '../GlobalUI'
 import Control from '../Control'
@@ -152,7 +153,7 @@ export const topicCreated = self => data => {
 }
 
 export const messageCreated = self => data => {
-  self.room.addMessages(new DataModel.MessageCollection(data))
+  ChatView.addMessages(new DataModel.MessageCollection(data))
 }
 
 export const mapUpdated = self => data => {
@@ -230,10 +231,10 @@ export const lostMapper = self => data => {
   // data.userid
   // data.username
   delete self.mappersOnMap[data.userid]
-  self.room.chat.sound.play('leavemap')
+  ChatView.sound.play('leavemap')
   // $('#mapper' + data.userid).remove()
   $('#compass' + data.userid).remove()
-  self.room.chat.removeParticipant(data.username)
+  ChatView.removeParticipant(data.username)
 
   GlobalUI.notifyUser(data.username + ' just left the map')
 
@@ -262,8 +263,8 @@ export const mapperListUpdated = self => data => {
   }
 
   if (data.userid !== Active.Mapper.id) {
-    self.room.chat.addParticipant(self.mappersOnMap[data.userid])
-    if (data.userinconversation) self.room.chat.mapperJoinedCall(data.userid)
+    ChatView.addParticipant(self.mappersOnMap[data.userid])
+    if (data.userinconversation) ChatView.mapperJoinedCall(data.userid)
 
     // create a div for the collaborators compass
     self.createCompass(data.username, data.userid, data.avatar, self.mappersOnMap[data.userid].color)
@@ -291,8 +292,8 @@ export const newMapper = self => data => {
 
   // create an item for them in the realtime box
   if (data.userid !== Active.Mapper.id) {
-    self.room.chat.sound.play('joinmap')
-    self.room.chat.addParticipant(self.mappersOnMap[data.userid])
+    ChatView.sound.play('joinmap')
+    ChatView.addParticipant(self.mappersOnMap[data.userid])
 
     // create a div for the collaborators compass
     self.createCompass(data.username, data.userid, data.avatar, self.mappersOnMap[data.userid].color)
@@ -311,24 +312,24 @@ export const callAccepted = self => userid => {
   // const username = self.mappersOnMap[userid].name
   GlobalUI.notifyUser('Conversation starting...')
   self.joinCall()
-  self.room.chat.invitationAnswered(userid)
+  ChatView.invitationAnswered(userid)
 }
 
 export const callDenied = self => userid => {
   var username = self.mappersOnMap[userid].name
   GlobalUI.notifyUser(username + " didn't accept your invitation")
-  self.room.chat.invitationAnswered(userid)
+  ChatView.invitationAnswered(userid)
 }
 
 export const inviteDenied = self => userid => {
   var username = self.mappersOnMap[userid].name
   GlobalUI.notifyUser(username + " didn't accept your invitation")
-  self.room.chat.invitationAnswered(userid)
+  ChatView.invitationAnswered(userid)
 }
 
 export const invitedToCall = self => inviter => {
-  self.room.chat.sound.stop(self.soundId)
-  self.soundId = self.room.chat.sound.play('sessioninvite')
+  ChatView.sound.stop(self.soundId)
+  self.soundId = ChatView.sound.play('sessioninvite')
 
   var username = self.mappersOnMap[inviter].name
   var notifyText = '<img src="' + self['junto_spinner_darkgrey.gif'] + '" style="display: inline-block; margin-top: -12px; margin-bottom: -6px; vertical-align: top;" />'
@@ -341,8 +342,8 @@ export const invitedToCall = self => inviter => {
 }
 
 export const invitedToJoin = self => inviter => {
-  self.room.chat.sound.stop(self.soundId)
-  self.soundId = self.room.chat.sound.play('sessioninvite')
+  ChatView.sound.stop(self.soundId)
+  self.soundId = ChatView.sound.play('sessioninvite')
 
   var username = self.mappersOnMap[inviter].name
   var notifyText = username + ' is inviting you to the conversation. Join?'
@@ -355,16 +356,14 @@ export const invitedToJoin = self => inviter => {
 
 export const mapperJoinedCall = self => id => {
   var mapper = self.mappersOnMap[id]
-
   if (mapper) {
     if (self.inConversation) {
       var username = mapper.name
       var notifyText = username + ' joined the call'
       GlobalUI.notifyUser(notifyText)
     }
-
     mapper.inConversation = true
-    self.room.chat.mapperJoinedCall(id)
+    ChatView.mapperJoinedCall(id)
   }
 }
 
@@ -377,7 +376,7 @@ export const mapperLeftCall = self => id => {
       GlobalUI.notifyUser(notifyText)
     }
     mapper.inConversation = false
-    self.room.chat.mapperLeftCall(id)
+    ChatView.mapperLeftCall(id)
     if ((self.inConversation && self.countOthersInConversation() === 0) ||
       (!self.inConversation && self.countOthersInConversation() === 1)) {
       self.callEnded()
@@ -392,8 +391,7 @@ export const callInProgress = self => () => {
   GlobalUI.notifyUser(notifyText, true)
   $('#toast button.yes').click(e => self.joinCall())
   $('#toast button.no').click(e => GlobalUI.clearNotify())
-
-  self.room.conversationInProgress()
+  ChatView.conversationInProgress() 
 }
 
 export const callStarted = self => () => {
@@ -404,7 +402,6 @@ export const callStarted = self => () => {
   GlobalUI.notifyUser(notifyText, true)
   $('#toast button.yes').click(e => self.joinCall())
   $('#toast button.no').click(e => GlobalUI.clearNotify())
-
-  self.room.conversationInProgress()
+  ChatView.conversationInProgress()
 }
 

--- a/frontend/src/Metamaps/Realtime/sendable.js
+++ b/frontend/src/Metamaps/Realtime/sendable.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import Active from '../Active'
+import { ChatView } from '../Views'
 import GlobalUI from '../GlobalUI'
 
 import {
@@ -72,6 +73,7 @@ export const joinCall = self => () => {
       $('#wrapper').append(self.localVideo.view.$container)
     }
     self.room.join()
+    ChatView.conversationInProgress(true)
   })
   self.inConversation = true
   self.socket.emit(JOIN_CALL, {
@@ -80,7 +82,7 @@ export const joinCall = self => () => {
   })
   self.webrtc.startLocalVideo()
   GlobalUI.clearNotify()
-  self.room.chat.mapperJoinedCall(Active.Mapper.id)
+  ChatView.mapperJoinedCall(Active.Mapper.id)
 }
 
 export const leaveCall = self => () => {
@@ -89,7 +91,8 @@ export const leaveCall = self => () => {
     id: Active.Mapper.id
   })
 
-  self.room.chat.mapperLeftCall(Active.Mapper.id)
+  ChatView.mapperLeftCall(Active.Mapper.id)
+  ChatView.leaveConversation() // the conversation will carry on without you
   self.room.leaveVideoOnly()
   self.inConversation = false
   self.localVideo.view.$container.hide()
@@ -102,7 +105,7 @@ export const leaveCall = self => () => {
 }
 
 export const acceptCall = self => userid => {
-  self.room.chat.sound.stop(self.soundId)
+  ChatView.sound.stop(self.soundId)
   self.socket.emit(ACCEPT_CALL, {
     mapid: Active.Map.id,
     invited: Active.Mapper.id,
@@ -114,7 +117,7 @@ export const acceptCall = self => userid => {
 }
 
 export const denyCall = self => userid => {
-  self.room.chat.sound.stop(self.soundId)
+  ChatView.sound.stop(self.soundId)
   self.socket.emit(DENY_CALL, {
     mapid: Active.Map.id,
     invited: Active.Mapper.id,
@@ -124,7 +127,7 @@ export const denyCall = self => userid => {
 }
 
 export const denyInvite = self => userid => {
-  self.room.chat.sound.stop(self.soundId)
+  ChatView.sound.stop(self.soundId)
   self.socket.emit(DENY_INVITE, {
     mapid: Active.Map.id,
     invited: Active.Mapper.id,
@@ -139,7 +142,7 @@ export const inviteACall = self => userid => {
     inviter: Active.Mapper.id,
     invited: userid
   })
-  self.room.chat.invitationPending(userid)
+  ChatView.invitationPending(userid)
   GlobalUI.clearNotify()
 }
 
@@ -149,7 +152,7 @@ export const inviteToJoin = self => userid => {
     inviter: Active.Mapper.id,
     invited: userid
   })
-  self.room.chat.invitationPending(userid)
+  ChatView.invitationPending(userid)
 }
 
 export const sendCoords = self => coords => {

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -120,16 +120,10 @@ const ChatView = {
     ChatView.render()
   },
   close: () => {
-    // TODO how to do focus with react
-    // this.$messageInput.blur()
     ChatView.mapChat.close()
   },
   open: () => {
     ChatView.mapChat.open()
-    // TODO how to do focus with react
-    // this.$messageInput.focus()
-    // TODO reimplement scrollMessages
-    // this.scrollMessages(0)
   },
   videoToggleClick: function() {
     ChatView.videosShowing = !ChatView.videosShowing
@@ -153,10 +147,8 @@ const ChatView = {
     if (!isInitial) self.mapChat.newMessage() 
     if (!wasMe && !isInitial && self.alertSound) self.sound.play('receivechat')
     self.messages.add(message)
-    // TODO what is scrollMessages?
-    // scrollMessages scrolls to the bottom of the div when there's new messages“
-    // if (!isInitial) self.scrollMessages(200)
     self.render()
+    if (!isInitial) self.mapChat.scroll()
   },
   sendChatMessage: message => {
     var self = ChatView

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -8,6 +8,8 @@ import outdent from 'outdent'
 // TODO is this line good or bad
 // Backbone.$ = window.$
 
+import MapChat from '../../components/MapChat'
+
 const linker = new Autolinker({ newWindow: true, truncate: 50, email: false, phone: false })
 
 var Private = {
@@ -226,28 +228,60 @@ var Handlers = {
   }
 }
 
-const ChatView = function(messages, mapper, room, opts = {}) {
-  this.room = room
-  this.mapper = mapper
-  this.messages = messages // backbone collection
+const ChatView = {
+  init: function(messages, mapper, room, opts = {}) {
+    const self = ChatView
+    self.room = room
+    self.mapper = mapper
+    self.messages = messages // backbone collection
 
-  this.isOpen = false
-  this.alertSound = true // whether to play sounds on arrival of new messages or not
-  this.cursorsShowing = true
-  this.videosShowing = true
-  this.unreadMessages = 0
-  this.participants = new Backbone.Collection()
+    self.isOpen = false
+    self.alertSound = true // whether to play sounds on arrival of new messages or not
+    self.cursorsShowing = true
+    self.videosShowing = true
+    self.unreadMessages = 0
+    self.participants = []
 
-  Private.templates.call(this)
-  Private.createElements.call(this)
-  Private.attachElements.call(this)
-  Private.addEventListeners.call(this)
-  Private.initialMessages.call(this)
-  Private.initializeSounds.call(this, opts.soundUrls)
-  this.$container.css({
-    right: '-300px'
-  })
+    // TODO reimplement
+    //Private.addEventListeners.call(this)
+    //Private.initialMessages.call(this)
+    //Private.initializeSounds.call(this, opts.soundUrls)
+    //this.$container.css({
+    //  right: '-300px'
+    //})
+  },
+  addWrapper: () => {
+    $('body').prepend('<div id="chat-box-wrapper"></div>')
+  },
+  render: () => {
+    const self = ChatView
+    ReactDOM.render(React.createElement(MapChat, {
+      show: self.show,
+      leaveCall: Realtime.leaveCall(),
+      joinCall: Realtime.joinCall(),
+      participants: self.participants
+    }))
+  }
+  show: () => {
+    ChatView.show = true
+    ChatView.render()
+  },
+  hide: () => {
+    ChatView.show = false
+    ChatView.render()
+  },
+  addParticipant: participant => {
+    const p = clone(participant.attributes)
+    ChatView.participants.push(p)
+    ChatView.render()
+  },
+  removeParticipant: participant => {
+    const remove_id = participant.get('id')
+    ChatView.participants = ChatView.participants.filter(p => p.id !== remove_id)
+    ChatView.render()
+  }
 }
+
 
 ChatView.prototype.conversationInProgress = function(participating) {
   this.$conversationInProgress.show()

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -59,6 +59,8 @@ const ChatView = {
       onClose: self.onClose,
       leaveCall: Realtime.leaveCall,
       joinCall: Realtime.joinCall,
+      inviteACall: Realtime.inviteACall,
+      inviteToJoin: Realtime.inviteToJoin,
       participants: self.participants.models.map(p => p.attributes),
       messages: self.messages.models.map(m => m.attributes),
       videoToggleClick: self.videoToggleClick,
@@ -92,7 +94,7 @@ const ChatView = {
     mapper && mapper.set('isParticipating', true)
     ChatView.render()
   },
-  mapperLeftCall: () => {
+  mapperLeftCall: id => {
     const mapper = ChatView.participants.findWhere({id})
     mapper && mapper.set('isParticipating', false)
     ChatView.render()

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -10,6 +10,7 @@ import ReactDOM from 'react-dom'
 // TODO is this line good or bad
 // Backbone.$ = window.$
 
+import Realtime from '../Realtime'
 import MapChat from '../../components/MapChat'
 
 const linker = new Autolinker({ newWindow: true, truncate: 50, email: false, phone: false })
@@ -68,12 +69,12 @@ const ChatView = {
   render: () => {
     const self = ChatView
     ReactDOM.render(React.createElement(MapChat, {
-      show: self.show,
-      leaveCall: Realtime.leaveCall(),
-      joinCall: Realtime.joinCall(),
+      isOpen: self.isOpen,
+      leaveCall: Realtime.leaveCall,
+      joinCall: Realtime.joinCall,
       participants: self.participants,
       unreadMessages: self.unreadMessages
-    }))
+    }), document.getElementById('chat-box-wrapper'))
   },
   show: () => {
     ChatView.show = true
@@ -127,6 +128,26 @@ const ChatView = {
     // TODO set textarea to be empty in react
     $(document).trigger(ChatView.events.message + '-' + this.room, [{ message: text }])
   },
+  leaveConversation: () => {
+    // TODO refactor
+    // this.$participants.removeClass('is-participating')
+  },
+  mapperJoinedCall: () => {
+    // TODO refactor
+    // this.$participants.find('.participant-' + id).addClass('active')
+  },
+  mapperLeftCall: () => {
+    // TODO refactor
+    // this.$participants.find('.participant-' + id).removeClass('active')
+  },
+  invitationPending: () => {
+    // TODO refactor
+    // this.$participants.find('.participant-' + id).addClass('pending')
+  },
+  invitationAnswered: () => {
+    // TODO refactor
+    // this.$participants.find('.participant-' + id).removeClass('pending')
+  }
 }
 
 var Handlers = {
@@ -163,101 +184,82 @@ var Handlers = {
   }
 }
 
-ChatView.prototype.conversationInProgress = function(participating) {
-  this.$conversationInProgress.show()
-  this.$participants.addClass('is-live')
-  if (participating) this.$participants.addClass('is-participating')
-  this.$button.addClass('active')
-}
+// ChatView.prototype.conversationInProgress = function(participating) {
+//   this.$conversationInProgress.show()
+//   this.$participants.addClass('is-live')
+//   if (participating) this.$participants.addClass('is-participating')
+//   this.$button.addClass('active')
+// }
 
-ChatView.prototype.conversationEnded = function() {
-  this.$conversationInProgress.hide()
-  this.$participants.removeClass('is-live')
-  this.$participants.removeClass('is-participating')
-  this.$button.removeClass('active')
-  this.$participants.find('.participant').removeClass('active')
-  this.$participants.find('.participant').removeClass('pending')
-}
+// ChatView.prototype.conversationEnded = function() {
+//   this.$conversationInProgress.hide()
+//   this.$participants.removeClass('is-live')
+//   this.$participants.removeClass('is-participating')
+//   this.$button.removeClass('active')
+//   this.$participants.find('.participant').removeClass('active')
+//   this.$participants.find('.participant').removeClass('pending')
+// }
 
-ChatView.prototype.leaveConversation = function() {
-  this.$participants.removeClass('is-participating')
-}
 
-ChatView.prototype.mapperJoinedCall = function(id) {
-  this.$participants.find('.participant-' + id).addClass('active')
-}
+// ChatView.prototype.addParticipant = function(participant) {
+//   this.participants.add(participant)
+// }
 
-ChatView.prototype.mapperLeftCall = function(id) {
-  this.$participants.find('.participant-' + id).removeClass('active')
-}
+// ChatView.prototype.removeParticipant = function(username) {
+//   var p = this.participants.find(p => p.get('username') === username)
+//   if (p) {
+//     this.participants.remove(p)
+//   }
+// }
 
-ChatView.prototype.invitationPending = function(id) {
-  this.$participants.find('.participant-' + id).addClass('pending')
-}
+// ChatView.prototype.removeParticipants = function() {
+//   this.participants.remove(this.participants.models)
+// }
 
-ChatView.prototype.invitationAnswered = function(id) {
-  this.$participants.find('.participant-' + id).removeClass('pending')
-}
+// ChatView.prototype.open = function() {
+//   this.$container.css({
+//     right: '0'
+//   })
+//   this.$messageInput.focus()
+//   this.isOpen = true
+//   this.unreadMessages = 0
+//   this.$unread.hide()
+//   this.scrollMessages(0)
+//   $(document).trigger(ChatView.events.openTray)
+// }
 
-ChatView.prototype.addParticipant = function(participant) {
-  this.participants.add(participant)
-}
+// ChatView.prototype.addMessage = function(message, isInitial, wasMe) {
+//   this.messages.add(message)
+//   Private.addMessage.call(this, message, isInitial, wasMe)
+// }
+//
+// ChatView.prototype.scrollMessages = function(duration) {
+//   duration = duration || 0
 
-ChatView.prototype.removeParticipant = function(username) {
-  var p = this.participants.find(p => p.get('username') === username)
-  if (p) {
-    this.participants.remove(p)
-  }
-}
+//   this.$messages.animate({
+//     scrollTop: this.$messages[0].scrollHeight
+//   }, duration)
+// }
 
-ChatView.prototype.removeParticipants = function() {
-  this.participants.remove(this.participants.models)
-}
+// ChatView.prototype.clearMessages = function() {
+//   this.unreadMessages = 0
+//   this.$unread.hide()
+//   this.$messages.empty()
+// }
 
-ChatView.prototype.open = function() {
-  this.$container.css({
-    right: '0'
-  })
-  this.$messageInput.focus()
-  this.isOpen = true
-  this.unreadMessages = 0
-  this.$unread.hide()
-  this.scrollMessages(0)
-  $(document).trigger(ChatView.events.openTray)
-}
+// ChatView.prototype.close = function() {
+//   this.$container.css({
+//     right: '-300px'
+//   })
+//   this.$messageInput.blur()
+//   this.isOpen = false
+//   $(document).trigger(ChatView.events.closeTray)
+// }
 
-ChatView.prototype.addMessage = function(message, isInitial, wasMe) {
-  this.messages.add(message)
-  Private.addMessage.call(this, message, isInitial, wasMe)
-}
-
-ChatView.prototype.scrollMessages = function(duration) {
-  duration = duration || 0
-
-  this.$messages.animate({
-    scrollTop: this.$messages[0].scrollHeight
-  }, duration)
-}
-
-ChatView.prototype.clearMessages = function() {
-  this.unreadMessages = 0
-  this.$unread.hide()
-  this.$messages.empty()
-}
-
-ChatView.prototype.close = function() {
-  this.$container.css({
-    right: '-300px'
-  })
-  this.$messageInput.blur()
-  this.isOpen = false
-  $(document).trigger(ChatView.events.closeTray)
-}
-
-ChatView.prototype.remove = function() {
-  this.$button.off()
-  this.$container.remove()
-}
+// ChatView.prototype.remove = function() {
+//   this.$button.off()
+//   this.$container.remove()
+// }
 
 /**
  * @class

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -16,13 +16,13 @@ import MapChat from '../../components/MapChat'
 const linker = new Autolinker({ newWindow: true, truncate: 50, email: false, phone: false })
 
 const ChatView = {
+  isOpen: false,
   init: function(messages, mapper, room, opts = {}) {
     const self = ChatView
     self.room = room
     self.mapper = mapper
     self.messages = messages
 
-    self.isOpen = false
     self.alertSound = true // whether to play sounds on arrival of new messages or not
     self.cursorsShowing = true
     self.videosShowing = true
@@ -44,13 +44,13 @@ const ChatView = {
   render: () => {
     const self = ChatView
     ReactDOM.render(React.createElement(MapChat, {
-      isOpen: self.isOpen,
+      onOpen: self.onOpen,
+      onClose: self.onClose,
       leaveCall: Realtime.leaveCall,
       joinCall: Realtime.joinCall,
       participants: self.participants,
       messages: self.messages.models.map(m => m.attributes),
       unreadMessages: self.unreadMessages,
-      buttonClick: self.buttonClick,
       videoToggleClick: self.videoToggleClick,
       cursorToggleClick: self.cursorToggleClick,
       soundToggleClick: self.soundToggleClick,
@@ -62,13 +62,13 @@ const ChatView = {
       handleInputMessage: self.handleInputMessage
     }), document.getElementById('chat-box-wrapper'))
   },
-  show: () => {
-    ChatView.show = true
-    ChatView.render()
+  onOpen: () => {
+    ChatView.isOpen = true
+    $(document).trigger(ChatView.events.openTray)
   },
-  hide: () => {
-    ChatView.show = false
-    ChatView.render()
+  onClose: () => {
+    ChatView.isOpen = false
+    $(document).trigger(ChatView.events.closeTray)
   },
   addParticipant: participant => {
     // TODO this should probably be using a Backbone collection????
@@ -107,6 +107,7 @@ const ChatView = {
 
     self.messages.push(m)
     // TODO what is scrollMessages?
+    // scrollMessages scrolls to the bottom of the div when there's new messages“
     // if (!isInitial) self.scrollMessages(200)
     self.render()
 
@@ -137,30 +138,16 @@ const ChatView = {
     // TODO refactor
     // this.$participants.find('.participant-' + id).removeClass('pending')
   },
-  buttonClick: () => {
-    const self = ChatView
-    if (self.isOpen) self.close()
-    else if (!self.isOpen) self.open()
-  },
   close: () => {
-    this.isOpen = false
-
     // TODO how to do focus with react
     // this.$messageInput.blur()
-
-    $(document).trigger(ChatView.events.closeTray)
-    ChatView.render()
   },
   open: () => {
     ChatView.unreadMessages = 0
-    this.isOpen = true
-
     // TODO how to do focus with react
     // this.$messageInput.focus()
     // TODO reimplement scrollMessages
     // this.scrollMessages(0)
-
-    $(document).trigger(ChatView.events.openTray)
     ChatView.render()
   },
   videoToggleClick: function() {

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -10,6 +10,7 @@ import ReactDOM from 'react-dom'
 // TODO is this line good or bad
 // Backbone.$ = window.$
 
+import Active from '../Active'
 import Realtime from '../Realtime'
 import MapChat from '../../components/MapChat'
 
@@ -18,7 +19,21 @@ const linker = new Autolinker({ newWindow: true, truncate: 50, email: false, pho
 const ChatView = {
   isOpen: false,
   mapChat: null,
-  init: function(messages, mapper, room, opts = {}) {
+  domId: 'chat-box-wrapper',
+  init: function(urls) {
+    const self = ChatView
+    self.sound = new Howl({
+      src: urls,
+      sprite: {
+        joinmap: [0, 561],
+        leavemap: [1000, 592],
+        receivechat: [2000, 318],
+        sendchat: [3000, 296],
+        sessioninvite: [4000, 5393, true]
+      }
+    })
+  },
+  setNewMap: function(messages, mapper, room) {
     const self = ChatView
     self.room = room
     self.mapper = mapper
@@ -28,20 +43,16 @@ const ChatView = {
     self.cursorsShowing = true
     self.videosShowing = true
     self.participants = []
-
-    self.sound = new Howl({
-      src: opts.soundUrls,
-      sprite: {
-        joinmap: [0, 561],
-        leavemap: [1000, 592],
-        receivechat: [2000, 318],
-        sendchat: [3000, 296],
-        sessioninvite: [4000, 5393, true]
-      }
-    })
-    $('body').prepend('<div id="chat-box-wrapper"></div>')
+    self.render()
+  },
+  show: () => {
+    $('#' + ChatView.domId).show()
+  },
+  hide: () => {
+    $('#' + ChatView.domId).hide()
   },
   render: () => {
+    if (!Active.Map) return    
     const self = ChatView
     self.mapChat = ReactDOM.render(React.createElement(MapChat, {
       onOpen: self.onOpen,
@@ -55,11 +66,8 @@ const ChatView = {
       soundToggleClick: self.soundToggleClick,
       inputBlur: self.inputBlur,
       inputFocus: self.inputFocus,
-      videosShowing: self.videosShowing,
-      cursorsShowing: self.cursorsShowing,
-      alertSound: self.alertSound,
       handleInputMessage: self.handleInputMessage
-    }), document.getElementById('chat-box-wrapper'))
+    }), document.getElementById(ChatView.domId))
   },
   onOpen: () => {
     $(document).trigger(ChatView.events.openTray)
@@ -144,21 +152,15 @@ const ChatView = {
     // this.scrollMessages(0)
   },
   videoToggleClick: function() {
-    const self = ChatView
-    self.videosShowing = !self.videosShowing
-    $(document).trigger(self.videosShowing ? ChatView.events.videosOn : ChatView.events.videosOff)
-    ChatView.render()
+    ChatView.videosShowing = !ChatView.videosShowing
+    $(document).trigger(ChatView.videosShowing ? ChatView.events.videosOn : ChatView.events.videosOff)
   },
   cursorToggleClick: function() {
-    const self = ChatView
-    self.cursorsShowing = !self.cursorsShowing
-    $(document).trigger(self.cursorsShowing ? ChatView.events.cursorsOn : ChatView.events.cursorsOff)
-    ChatView.render()
+    ChatView.cursorsShowing = !ChatView.cursorsShowing
+    $(document).trigger(ChatView.cursorsShowing ? ChatView.events.cursorsOn : ChatView.events.cursorsOff)
   },
   soundToggleClick: function() {
-    const self = ChatView
-    this.alertSound = !this.alertSound
-    ChatView.render()
+    ChatView.alertSound = !ChatView.alertSound
   },
   inputFocus: () => {
     $(document).trigger(ChatView.events.inputFocus)

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -32,9 +32,8 @@ const ChatView = {
       }
     })
   },
-  setNewMap: function(room) {
+  setNewMap: function() {
     const self = ChatView
-    self.room = room
     self.conversationLive = false
     self.isParticipating = false
     self.alertSound = true // whether to play sounds on arrival of new messages or not

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -39,31 +39,6 @@ const ChatView = {
         sessioninvite: [4000, 5393, true]
       }
     })
-
-    // TODO move these event handlers into react
-    // this.$button.on('click', function() {
-    //   Handlers.buttonClick.call(self)
-    // })
-    // this.$videoToggle.on('click', function() {
-    //   Handlers.videoToggleClick.call(self)
-    // })
-    // this.$cursorToggle.on('click', function() {
-    //   Handlers.cursorToggleClick.call(self)
-    // })
-    // this.$soundToggle.on('click', function() {
-    //   Handlers.soundToggleClick.call(self)
-    // })
-    // this.$messageInput.on('keyup', function(event) {
-    //   Handlers.keyUp.call(self, event)
-    // })
-    // this.$messageInput.on('focus', function() {
-    //   Handlers.inputFocus.call(self)
-    // })
-    // this.$messageInput.on('blur', function() {
-    //   Handlers.inputBlur.call(self)
-    // })
-  },
-  addWrapper: () => {
     $('body').prepend('<div id="chat-box-wrapper"></div>')
   },
   render: () => {
@@ -73,7 +48,18 @@ const ChatView = {
       leaveCall: Realtime.leaveCall,
       joinCall: Realtime.joinCall,
       participants: self.participants,
-      unreadMessages: self.unreadMessages
+      messages: self.messages,
+      unreadMessages: self.unreadMessages,
+      buttonClick: self.buttonClick,
+      videoToggleClick: self.videoToggleClick,
+      cursorToggleClick: self.cursorToggleClick,
+      soundToggleClick: self.soundToggleClick,
+      inputBlur: self.inputBlur,
+      inputFocus: self.inputFocus,
+      videosShowing: self.videosShowing,
+      cursorsShowing: self.cursorsShowing,
+      alertSound: self.alertSound,
+      handleInputMessage: self.handleInputMessage
     }), document.getElementById('chat-box-wrapper'))
   },
   show: () => {
@@ -85,7 +71,7 @@ const ChatView = {
     ChatView.render()
   },
   addParticipant: participant => {
-    const p = clone(participant.attributes)
+    const p = participant.attributes ? clone(participant.attributes) : participant
     ChatView.participants.push(p)
     ChatView.render()
   },
@@ -119,14 +105,13 @@ const ChatView = {
 
     self.messages.push(m)
     // TODO what is scrollMessages?
-    if (!isInitial) this.scrollMessages(200)
+    // if (!isInitial) self.scrollMessages(200)
     self.render()
 
-    if (!wasMe && !isInitial && this.alertSound) this.sound.play('receivechat')
+    if (!wasMe && !isInitial && self.alertSound) self.sound.play('receivechat')
   },
   handleInputMessage: text => {
-    // TODO set textarea to be empty in react
-    $(document).trigger(ChatView.events.message + '-' + this.room, [{ message: text }])
+    $(document).trigger(ChatView.events.message + '-' + self.room, [{ message: text }])
   },
   leaveConversation: () => {
     // TODO refactor
@@ -147,39 +132,54 @@ const ChatView = {
   invitationAnswered: () => {
     // TODO refactor
     // this.$participants.find('.participant-' + id).removeClass('pending')
-  }
-}
+  },
+  buttonClick: () => {
+    const self = ChatView
+    if (self.isOpen) self.close()
+    else if (!self.isOpen) self.open()
+  },
+  close: () => {
+    this.isOpen = false
 
-var Handlers = {
-  buttonClick: function() {
-    if (this.isOpen) this.close()
-    else if (!this.isOpen) this.open()
+    // TODO how to do focus with react
+    // this.$messageInput.blur()
+
+    $(document).trigger(ChatView.events.closeTray)
+    ChatView.render()
+  },
+  open: () => {
+    ChatView.unreadMessages = 0
+    this.isOpen = true
+
+    // TODO how to do focus with react
+    // this.$messageInput.focus()
+    // TODO reimplement scrollMessages
+    // this.scrollMessages(0)
+
+    $(document).trigger(ChatView.events.openTray)
+    ChatView.render()
   },
   videoToggleClick: function() {
-    this.$videoToggle.toggleClass('active')
-    this.videosShowing = !this.videosShowing
-    $(document).trigger(this.videosShowing ? ChatView.events.videosOn : ChatView.events.videosOff)
+    const self = ChatView
+    self.videosShowing = !self.videosShowing
+    $(document).trigger(self.videosShowing ? ChatView.events.videosOn : ChatView.events.videosOff)
+    ChatView.render()
   },
   cursorToggleClick: function() {
-    this.$cursorToggle.toggleClass('active')
-    this.cursorsShowing = !this.cursorsShowing
-    $(document).trigger(this.cursorsShowing ? ChatView.events.cursorsOn : ChatView.events.cursorsOff)
+    const self = ChatView
+    self.cursorsShowing = !self.cursorsShowing
+    $(document).trigger(self.cursorsShowing ? ChatView.events.cursorsOn : ChatView.events.cursorsOff)
+    ChatView.render()
   },
   soundToggleClick: function() {
+    const self = ChatView
     this.alertSound = !this.alertSound
-    this.$soundToggle.toggleClass('active')
+    ChatView.render()
   },
-  keyUp: function(event) {
-    switch (event.which) {
-      case 13: // enter
-        Private.handleInputMessage.call(this)
-        break
-    }
-  },
-  inputFocus: function() {
+  inputFocus: () => {
     $(document).trigger(ChatView.events.inputFocus)
   },
-  inputBlur: function() {
+  inputBlur: () => {
     $(document).trigger(ChatView.events.inputBlur)
   }
 }
@@ -200,32 +200,8 @@ var Handlers = {
 //   this.$participants.find('.participant').removeClass('pending')
 // }
 
-
-// ChatView.prototype.addParticipant = function(participant) {
-//   this.participants.add(participant)
-// }
-
-// ChatView.prototype.removeParticipant = function(username) {
-//   var p = this.participants.find(p => p.get('username') === username)
-//   if (p) {
-//     this.participants.remove(p)
-//   }
-// }
-
 // ChatView.prototype.removeParticipants = function() {
 //   this.participants.remove(this.participants.models)
-// }
-
-// ChatView.prototype.open = function() {
-//   this.$container.css({
-//     right: '0'
-//   })
-//   this.$messageInput.focus()
-//   this.isOpen = true
-//   this.unreadMessages = 0
-//   this.$unread.hide()
-//   this.scrollMessages(0)
-//   $(document).trigger(ChatView.events.openTray)
 // }
 
 // ChatView.prototype.addMessage = function(message, isInitial, wasMe) {
@@ -245,15 +221,6 @@ var Handlers = {
 //   this.unreadMessages = 0
 //   this.$unread.hide()
 //   this.$messages.empty()
-// }
-
-// ChatView.prototype.close = function() {
-//   this.$container.css({
-//     right: '-300px'
-//   })
-//   this.$messageInput.blur()
-//   this.isOpen = false
-//   $(document).trigger(ChatView.events.closeTray)
 // }
 
 // ChatView.prototype.remove = function() {

--- a/frontend/src/Metamaps/Views/ChatView.js
+++ b/frontend/src/Metamaps/Views/ChatView.js
@@ -20,7 +20,7 @@ const ChatView = {
     const self = ChatView
     self.room = room
     self.mapper = mapper
-    self.messages = messages.models.map(m => m.attributes)
+    self.messages = messages
 
     self.isOpen = false
     self.alertSound = true // whether to play sounds on arrival of new messages or not
@@ -48,7 +48,7 @@ const ChatView = {
       leaveCall: Realtime.leaveCall,
       joinCall: Realtime.joinCall,
       participants: self.participants,
-      messages: self.messages,
+      messages: self.messages.models.map(m => m.attributes),
       unreadMessages: self.unreadMessages,
       buttonClick: self.buttonClick,
       videoToggleClick: self.videoToggleClick,
@@ -71,6 +71,7 @@ const ChatView = {
     ChatView.render()
   },
   addParticipant: participant => {
+    // TODO this should probably be using a Backbone collection????
     const p = participant.attributes ? clone(participant.attributes) : participant
     ChatView.participants.push(p)
     ChatView.render()
@@ -85,6 +86,7 @@ const ChatView = {
     if (render) ChatView.render()
   },
   addMessage: (message, isInitial, wasMe) => {
+    const self = ChatView
     if (!self.isOpen && !isInitial) ChatView.incrementUnread(false) // TODO don't need to render, right?
 
     function addZero(i) {
@@ -111,6 +113,8 @@ const ChatView = {
     if (!wasMe && !isInitial && self.alertSound) self.sound.play('receivechat')
   },
   handleInputMessage: text => {
+    // TODO use backbone
+    ChatView.addMessage(text, false, false)
     $(document).trigger(ChatView.events.message + '-' + self.room, [{ message: text }])
   },
   leaveConversation: () => {

--- a/frontend/src/Metamaps/Views/Room.js
+++ b/frontend/src/Metamaps/Views/Room.js
@@ -26,7 +26,8 @@ const Room = function(opts = {}) {
 
   this.messages = new Backbone.Collection()
   this.currentMapper = new Backbone.Model({ name: opts.username, image: opts.image })
-  this.chat = new ChatView(this.messages, this.currentMapper, this.room, {
+  this.chat = ChatView
+  this.chat.init(this.messages, this.currentMapper, this.room, {
     soundUrls: opts.soundUrls
   })
 

--- a/frontend/src/Metamaps/Views/Room.js
+++ b/frontend/src/Metamaps/Views/Room.js
@@ -26,10 +26,7 @@ const Room = function(opts = {}) {
 
   this.messages = new Backbone.Collection()
   this.currentMapper = new Backbone.Model({ name: opts.username, image: opts.image })
-  this.chat = ChatView
-  this.chat.init(this.messages, this.currentMapper, this.room, {
-    soundUrls: opts.soundUrls
-  })
+  ChatView.setNewMap(this.messages, this.currentMapper, this.room)
 
   this.videos = {}
 
@@ -39,19 +36,19 @@ const Room = function(opts = {}) {
 Room.prototype.join = function(cb) {
   this.isActiveRoom = true
   this.webrtc.joinRoom(this.room, cb)
-  this.chat.conversationInProgress(true) // true indicates participation
+  ChatView.conversationInProgress(true) // true indicates participation
 }
 
 Room.prototype.conversationInProgress = function() {
-  this.chat.conversationInProgress(false) // false indicates not participating
+  ChatView.conversationInProgress(false) // false indicates not participating
 }
 
 Room.prototype.conversationEnding = function() {
-  this.chat.conversationEnded()
+  ChatView.conversationEnded()
 }
 
 Room.prototype.leaveVideoOnly = function() {
-  this.chat.leaveConversation() // the conversation will carry on without you
+  ChatView.leaveConversation() // the conversation will carry on without you
   for (var id in this.videos) {
     this.removeVideo(id)
   }
@@ -67,9 +64,9 @@ Room.prototype.leave = function() {
   this.isActiveRoom = false
   this.webrtc.leaveRoom()
   this.webrtc.stopLocalVideo()
-  this.chat.conversationEnded()
-  this.chat.removeParticipants()
-  this.chat.clearMessages()
+  ChatView.conversationEnded()
+  ChatView.removeParticipants()
+  ChatView.clearMessages()
   this.messages.reset()
 }
 
@@ -161,8 +158,7 @@ Room.prototype.removeVideo = function(peer) {
 
 Room.prototype.sendChatMessage = function(data) {
   var self = this
-      // this.roomRef.child('messages').push(data)
-  if (self.chat.alertSound) self.chat.sound.play('sendchat')
+  if (ChatView.alertSound) ChatView.sound.play('sendchat')
   var m = new DataModel.Message({
     message: data.message,
     resource_id: Active.Map.id,
@@ -185,7 +181,7 @@ Room.prototype.addMessages = function(messages, isInitial, wasMe) {
   var self = this
 
   messages.models.forEach(function(message) {
-    self.chat.addMessage(message, isInitial, wasMe)
+    ChatView.addMessage(message, isInitial, wasMe)
   })
 }
 

--- a/frontend/src/Metamaps/Views/index.js
+++ b/frontend/src/Metamaps/Views/index.js
@@ -7,8 +7,9 @@ import Room from './Room'
 import { JUNTO_UPDATED } from '../Realtime/events'
 
 const Views = {
-  init: () => {
+  init: (serverData) => {
     $(document).on(JUNTO_UPDATED, () => ExploreMaps.render())
+    ChatView.init([serverData['sounds/MM_sounds.mp3'],serverData['sounds/MM_sounds.ogg']])
   },
   ExploreMaps,
   ChatView,

--- a/frontend/src/components/MapChat/Message.js
+++ b/frontend/src/components/MapChat/Message.js
@@ -19,12 +19,13 @@ function formatDate(created_at) {
 
 const Message = props => {
   const { user_image, user_name, message, created_at } = props
+  const messageHtml = {__html: linker.link(message)}
   return (
     <div className="chat-message">
       <div className="chat-message-user">
         <img src={user_image} title={user_name} />
       </div>
-      <div className="chat-message-text">{linker.link(message)}</div>
+      <div className="chat-message-text" dangerouslySetInnerHTML={messageHtml}></div>
       <div className="chat-message-time">{formatDate(created_at)}</div>
       <div className="clearfloat"></div>
     </div>

--- a/frontend/src/components/MapChat/Message.js
+++ b/frontend/src/components/MapChat/Message.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+const Message = props => {
+  const { user_image, user_name, message, timestamp } = props
+  return (
+    <div className="chat-message">
+      <div className="chat-message-user">
+        <img src={user_image} title={user_name} />
+      </div>
+      <div className="chat-message-text">{message}</div>
+      <div className="chat-message-time">{timestamp}</div>
+      <div className="clearfloat"></div>
+    </div>
+  )
+}
+
+export default Message

--- a/frontend/src/components/MapChat/Message.js
+++ b/frontend/src/components/MapChat/Message.js
@@ -1,14 +1,31 @@
 import React from 'react'
+import Autolinker from 'autolinker'
+
+const linker = new Autolinker({ newWindow: true, truncate: 50, email: false, phone: false })
+
+function addZero(i) {
+  if (i < 10) {
+    i = '0' + i
+  }
+  return i
+}
+
+function formatDate(created_at) {
+  let date = new Date(created_at)
+  let formatted = (date.getMonth() + 1) + '/' + date.getDate()
+  formatted += ' ' + addZero(date.getHours()) + ':' + addZero(date.getMinutes())
+  return formatted
+}
 
 const Message = props => {
-  const { user_image, user_name, message, timestamp } = props
+  const { user_image, user_name, message, created_at } = props
   return (
     <div className="chat-message">
       <div className="chat-message-user">
         <img src={user_image} title={user_name} />
       </div>
-      <div className="chat-message-text">{message}</div>
-      <div className="chat-message-time">{timestamp}</div>
+      <div className="chat-message-text">{linker.link(message)}</div>
+      <div className="chat-message-time">{formatDate(created_at)}</div>
       <div className="clearfloat"></div>
     </div>
   )

--- a/frontend/src/components/MapChat/Participant.js
+++ b/frontend/src/components/MapChat/Participant.js
@@ -12,12 +12,12 @@ class Participant extends Component {
 					{username} {self ? '(me)' : ''}
 				</div>
 				{!self && !conversationLive && <button
-					className='button chat-participant-invite-call'
-					onClick={() => this.props.inviteACall(id)} // Realtime.inviteACall(id)
+					className={`button chat-participant-invite-call ${isPending ? 'pending' : ''}`}
+					onClick={() => !isPending && this.props.inviteACall(id)} // Realtime.inviteACall(id)
 				/>}
 				{!self && mapperIsLive && !isParticipating && <button
-					className="button chat-participant-invite-join"
-					onClick={() => this.props.inviteToJoin(id)} // Realtime.inviteToJoin(id)
+					className={`button chat-participant-invite-join ${isPending ? 'pending' : ''}`}
+					onClick={() => !isPending && this.props.inviteToJoin(id)} // Realtime.inviteToJoin(id)
 				/>}
 				{isParticipating && <span className="chat-participant-participating">
 					<div className="green-dot"></div>

--- a/frontend/src/components/MapChat/Participant.js
+++ b/frontend/src/components/MapChat/Participant.js
@@ -1,0 +1,39 @@
+import React, { PropTypes, Component } from 'react'
+
+class Participant extends Component {
+  render() {
+    const { id, self, image, username, selfName, color } = this.props
+    return (
+			<div className={`participant participant-${id} ${self ? 'is-self' : ''}`}>
+				<div className="chat-participant-image">
+					<img src={image} style={{ border: `2px solid ${color}`}} />
+				</div>
+				<div className="chat-participant-name">
+					{username} {self ? '(me)' : ''}
+				</div>
+				<button
+					className='button chat-participant-invite-call'
+					onClick={this.props.inviteACall} // Realtime.inviteACall(id)
+				/>
+				<button
+					className="button chat-participant-invite-join"
+					onClick={this.props.inviteToJoin} // Realtime.inviteToJoin(id)
+				/>
+				<span className="chat-participant-participating">
+					<div className="green-dot"></div>
+				</span>
+				<div className="clearfloat"></div>
+			</div>
+    )
+  }
+}
+
+ChatView.propTypes = {
+  color: PropTypes.string // css color
+  id: PropTypes.number,
+  image: PropTypes.string, // image url
+  self: PropTypes.bool,
+  username: PropTypes.string,
+}
+
+export default ChatView

--- a/frontend/src/components/MapChat/Participant.js
+++ b/frontend/src/components/MapChat/Participant.js
@@ -11,11 +11,11 @@ class Participant extends Component {
 				<div className="chat-participant-name">
 					{username} {self ? '(me)' : ''}
 				</div>
-				{!conversationLive && <button
+				{!self && !conversationLive && <button
 					className='button chat-participant-invite-call'
 					onClick={this.props.inviteACall} // Realtime.inviteACall(id)
 				/>}
-				{mapperIsLive && !isParticipating && <button
+				{!self && mapperIsLive && !isParticipating && <button
 					className="button chat-participant-invite-join"
 					onClick={this.props.inviteToJoin} // Realtime.inviteToJoin(id)
 				/>}

--- a/frontend/src/components/MapChat/Participant.js
+++ b/frontend/src/components/MapChat/Participant.js
@@ -13,11 +13,11 @@ class Participant extends Component {
 				</div>
 				{!self && !conversationLive && <button
 					className='button chat-participant-invite-call'
-					onClick={this.props.inviteACall} // Realtime.inviteACall(id)
+					onClick={() => this.props.inviteACall(id)} // Realtime.inviteACall(id)
 				/>}
 				{!self && mapperIsLive && !isParticipating && <button
 					className="button chat-participant-invite-join"
-					onClick={this.props.inviteToJoin} // Realtime.inviteToJoin(id)
+					onClick={() => this.props.inviteToJoin(id)} // Realtime.inviteToJoin(id)
 				/>}
 				{isParticipating && <span className="chat-participant-participating">
 					<div className="green-dot"></div>
@@ -37,7 +37,9 @@ Participant.propTypes = {
   id: PropTypes.number,
   image: PropTypes.string, // image url
   self: PropTypes.bool,
-  username: PropTypes.string
+  username: PropTypes.string,
+  inviteACall: PropTypes.func,
+  inviteToJoin: PropTypes.func
 }
 
 export default Participant

--- a/frontend/src/components/MapChat/Participant.js
+++ b/frontend/src/components/MapChat/Participant.js
@@ -2,7 +2,7 @@ import React, { PropTypes, Component } from 'react'
 
 class Participant extends Component {
   render() {
-    const { id, self, image, username, selfName, color } = this.props
+    const { conversationLive, mapperIsLive, isParticipating, isPending, id, self, image, username, selfName, color } = this.props
     return (
 			<div className={`participant participant-${id} ${self ? 'is-self' : ''}`}>
 				<div className="chat-participant-image">
@@ -11,17 +11,17 @@ class Participant extends Component {
 				<div className="chat-participant-name">
 					{username} {self ? '(me)' : ''}
 				</div>
-				<button
+				{!conversationLive && <button
 					className='button chat-participant-invite-call'
 					onClick={this.props.inviteACall} // Realtime.inviteACall(id)
-				/>
-				<button
+				/>}
+				{mapperIsLive && !isParticipating && <button
 					className="button chat-participant-invite-join"
 					onClick={this.props.inviteToJoin} // Realtime.inviteToJoin(id)
-				/>
-				<span className="chat-participant-participating">
+				/>}
+				{isParticipating && <span className="chat-participant-participating">
 					<div className="green-dot"></div>
-				</span>
+				</span>}
 				<div className="clearfloat"></div>
 			</div>
     )
@@ -29,6 +29,10 @@ class Participant extends Component {
 }
 
 Participant.propTypes = {
+  conversationLive: PropTypes.bool,
+  mapperIsLive: PropTypes.bool,
+  isParticipating: PropTypes.bool,
+  isPending: PropTypes.bool,
   color: PropTypes.string, // css color
   id: PropTypes.number,
   image: PropTypes.string, // image url

--- a/frontend/src/components/MapChat/Participant.js
+++ b/frontend/src/components/MapChat/Participant.js
@@ -29,11 +29,11 @@ class Participant extends Component {
 }
 
 ChatView.propTypes = {
-  color: PropTypes.string // css color
+  color: PropTypes.string, // css color
   id: PropTypes.number,
   image: PropTypes.string, // image url
   self: PropTypes.bool,
-  username: PropTypes.string,
+  username: PropTypes.string
 }
 
 export default ChatView

--- a/frontend/src/components/MapChat/Participant.js
+++ b/frontend/src/components/MapChat/Participant.js
@@ -28,7 +28,7 @@ class Participant extends Component {
   }
 }
 
-ChatView.propTypes = {
+Participant.propTypes = {
   color: PropTypes.string, // css color
   id: PropTypes.number,
   image: PropTypes.string, // image url
@@ -36,4 +36,4 @@ ChatView.propTypes = {
   username: PropTypes.string
 }
 
-export default ChatView
+export default Participant

--- a/frontend/src/components/MapChat/Unread.js
+++ b/frontend/src/components/MapChat/Unread.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const Unread = props => {
+  if (props.count <= 0) {
+    return null
+  }
+  return <div className="chat-unread"></div>
+}
+
+export default Unread

--- a/frontend/src/components/MapChat/Unread.js
+++ b/frontend/src/components/MapChat/Unread.js
@@ -1,10 +1,7 @@
 import React from 'react'
 
 const Unread = props => {
-  if (props.count <= 0) {
-    return null
-  }
-  return <div className="chat-unread"></div>
+  return props.count ? <div className="chat-unread">{props.count}</div> : null
 }
 
 export default Unread

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -79,7 +79,7 @@ class MapChat extends Component {
 
   render = () => {
     const rightOffset = this.state.open ? '0' : '-300px'
-    const { conversationLive, isParticipating, participants, messages } = this.props
+    const { conversationLive, isParticipating, participants, messages, inviteACall, inviteToJoin } = this.props
     const { videosShowing, cursorsShowing, alertSound, unreadMessages } = this.state
     return (
       <div className="chat-box"
@@ -103,6 +103,8 @@ class MapChat extends Component {
           {participants.map(participant => <Participant
             key={participant.id}
             {...participant}
+            inviteACall={inviteACall}
+            inviteToJoin={inviteToJoin}
             conversationLive={conversationLive}
             mapperIsLive={isParticipating}/>
           )}
@@ -138,6 +140,8 @@ MapChat.propTypes = {
   onClose: PropTypes.func,
   leaveCall: PropTypes.func,
   joinCall: PropTypes.func,
+  inviteACall: PropTypes.func,
+  inviteToJoin: PropTypes.func,
   videoToggleClick: PropTypes.func,
   cursorToggleClick: PropTypes.func,
   soundToggleClick: PropTypes.func, 

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -4,16 +4,40 @@ import Participant from './Participant'
 import Message from './Message'
 
 class MapChat extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      messageText: ''
+    }
+  }
+
+  handleChange = key => e => {
+    this.setState({
+      [key]: e.target.value
+    })
+  }
+
+  handleTextareaKeyUp = e => {
+    if (e.which === 13) {
+      e.preventDefault()
+      const text = this.state.messageText
+      this.props.handleInputMessage(text)
+      this.setState({ messageText: '' })
+    }
+  }
+
   render = () => {
     const rightOffset = this.props.isOpen ? '-300px' : '0'
+    const { videosShowing, cursorsShowing, alertSound } = this.props
     return (
       <div className="chat-box"
         style={{ right: rightOffset }}
       >
         <div className="junto-header">
           PARTICIPANTS
-          <div className="video-toggle" />
-          <div className="cursor-toggle" />
+          <div className={`video-toggle ${videosShowing ? 'active' : ''}`} />
+          <div className={`cursor-toggle ${cursorsShowing ? 'active' : ''}`} />
         </div>
         <div className="participants">
           <div className="conversation-live">
@@ -25,17 +49,31 @@ class MapChat extends Component {
 							JOIN
 						</span>
           </div>
+          {this.props.participants.map(participant => {
+            return <Participant key={participant.id} {...participant} />
+          })}
         </div>
         <div className="chat-header">
           CHAT
-          <div className="sound-toggle"></div>
+          <div className={`sound-toggle ${alertSound ? 'active' : ''}`}></div>
         </div>
         <div className="chat-button">
           <div className="tooltips">Chat</div>
           <Unread count={this.props.unreadMessages} />
         </div>
-        <div className="chat-messages"></div>
-        <textarea className="chat-input" placeholder="Send a message..." />
+        <div className="chat-messages">
+          {this.props.messages.map(message => {
+            return <Message key={message.id} {...message} />
+          })}
+        </div>
+        <textarea className="chat-input"
+          placeholder="Send a message..."
+          value={this.state.messageText}
+          onChange={this.handleChange('messageText')}
+          onKeyUp={this.handleTextareaKeyUp}
+          onFocus={this.props.inputFocus}
+          onBlur={this.props.inputBlur}
+        />
       </div>
     )
   }

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -31,15 +31,22 @@ class MapChat extends Component {
   close = () => {
     this.setState({open: false})
     this.props.onClose()
+    this.messageInput.blur()
   }
 
   open = () => {
+    this.scroll()
     this.setState({open: true, unreadMessages: 0})
     this.props.onOpen()
+    this.messageInput.focus()
   }
 
   newMessage = () => {
     if (!this.state.open) this.setState({unreadMessages: this.state.unreadMessages + 1})
+  }
+
+  scroll = () => {
+    this.messagesDiv.scrollTop = this.messagesDiv.scrollHeight
   }
 
   toggleDrawer = () => {
@@ -117,10 +124,11 @@ class MapChat extends Component {
           <div className="tooltips">Chat</div>
           <Unread count={unreadMessages} />
         </div>
-        <div className="chat-messages">
+        <div className="chat-messages" ref={div => this.messagesDiv = div}>
           {messages.map(message => <Message key={message.id} {...message} />)}
         </div>
         <textarea className="chat-input"
+          ref={textarea => this.messageInput = textarea}
           placeholder="Send a message..."
           value={this.state.messageText}
           onChange={this.handleChange('messageText')}

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -8,7 +8,19 @@ class MapChat extends Component {
     super(props)
 
     this.state = {
+      open: false,
       messageText: ''
+    }
+  }
+
+  toggleDrawer = () => {
+    if (this.state.open) {
+      this.setState({open: false})
+      this.props.onClose()
+    }
+    else if (!this.state.open) {
+      this.setState({open: true})
+      this.props.onOpen()
     }
   }
 
@@ -28,7 +40,7 @@ class MapChat extends Component {
   }
 
   render = () => {
-    const rightOffset = this.props.isOpen ? '-300px' : '0'
+    const rightOffset = this.state.open ? '0' : '-300px'
     const { videosShowing, cursorsShowing, alertSound } = this.props
     return (
       <div className="chat-box"
@@ -57,7 +69,7 @@ class MapChat extends Component {
           CHAT
           <div className={`sound-toggle ${alertSound ? 'active' : ''}`}></div>
         </div>
-        <div className="chat-button">
+        <div className="chat-button" onClick={this.toggleDrawer}>
           <div className="tooltips">Chat</div>
           <Unread count={this.props.unreadMessages} />
         </div>
@@ -80,7 +92,8 @@ class MapChat extends Component {
 }
 
 MapChat.propTypes = {
-  isOpen: PropTypes.bool,
+  onOpen: PropTypes.func,
+  onClose: PropTypes.func,
   leaveCall: PropTypes.func,
   joinCall: PropTypes.func,
   participants: PropTypes.arrayOf(PropTypes.shape({

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -17,6 +17,17 @@ class MapChat extends Component {
     }
   }
 
+  reset = () => {
+    this.setState({
+      unreadMessages: 0,
+      open: false,
+      messageText: '',
+      alertSound: true, // whether to play sounds on arrival of new messages or not
+      cursorsShowing: true,
+      videosShowing:  true
+    })
+  }
+
   close = () => {
     this.setState({open: false})
     this.props.onClose()
@@ -28,7 +39,7 @@ class MapChat extends Component {
   }
 
   newMessage = () => {
-    if (!this.state.open) this.setState({ unreadMessages: this.state.unreadMessages + 1 })
+    if (!this.state.open) this.setState({unreadMessages: this.state.unreadMessages + 1})
   }
 
   toggleDrawer = () => {
@@ -68,7 +79,7 @@ class MapChat extends Component {
 
   render = () => {
     const rightOffset = this.state.open ? '0' : '-300px'
-    const { conversationLive } = this.props
+    const { conversationLive, isParticipating, participants, messages } = this.props
     const { videosShowing, cursorsShowing, alertSound, unreadMessages } = this.state
     return (
       <div className="chat-box"
@@ -100,7 +111,7 @@ class MapChat extends Component {
           CHAT
           <div onClick={this.toggleAlertSound} className={`sound-toggle ${alertSound ? '' : 'active'}`}></div>
         </div>
-        <div className="chat-button" onClick={this.toggleDrawer}>
+        <div className={`chat-button ${conversationLive ? 'active' : ''}`} onClick={this.toggleDrawer}>
           <div className="tooltips">Chat</div>
           <Unread count={unreadMessages} />
         </div>
@@ -136,7 +147,8 @@ MapChat.propTypes = {
     image: PropTypes.string, // image url
     self: PropTypes.bool,
     username: PropTypes.string,
-    isParticipating: PropTypes.bool
+    isParticipating: PropTypes.bool,
+    isPending: PropTypes.bool
   }))
 }
 

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -29,7 +29,7 @@ class MapChat extends Component {
         </div>
         <div className="chat-button">
           <div className="tooltips">Chat</div>
-          <div className="chat-unread"></div>
+          <Unread count={this.props.unreadMessages} />
         </div>
         <div className="chat-messages"></div>
         <textarea className="chat-input" placeholder="Send a message..." />
@@ -43,11 +43,11 @@ MapChat.propTypes = {
   leaveCall: PropTypes.func,
   joinCall: PropTypes.func,
   participants: PropTypes.arrayOf(PropTypes.shape({
-    color: PropTypes.string // css color
+    color: PropTypes.string, // css color
     id: PropTypes.number,
     image: PropTypes.string, // image url
     self: PropTypes.bool,
-    username: PropTypes.string,
+    username: PropTypes.string
   }))
 }
 

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -68,6 +68,7 @@ class MapChat extends Component {
 
   render = () => {
     const rightOffset = this.state.open ? '0' : '-300px'
+    const { conversationLive } = this.props
     const { videosShowing, cursorsShowing, alertSound, unreadMessages } = this.state
     return (
       <div className="chat-box"
@@ -79,18 +80,21 @@ class MapChat extends Component {
           <div onClick={this.toggleCursorsShowing} className={`cursor-toggle ${cursorsShowing ? '' : 'active'}`} />
         </div>
         <div className="participants">
-          <div className="conversation-live">
+          {conversationLive && <div className="conversation-live">
             LIVE
-						<span className="call-action leave" onClick={this.props.leaveCall}>
-							LEAVE
-						</span>
-						<span className="call-action join"  onClick={this.props.joinCall}>
-							JOIN
-						</span>
-          </div>
-          {this.props.participants.map(participant => {
-            return <Participant key={participant.id} {...participant} />
-          })}
+	      {isParticipating && <span className="call-action leave" onClick={this.props.leaveCall}>
+                LEAVE
+              </span>}
+              {!isParticipating && <span className="call-action join"  onClick={this.props.joinCall}>
+                JOIN
+              </span>}
+          </div>}
+          {participants.map(participant => <Participant
+            key={participant.id}
+            {...participant}
+            conversationLive={conversationLive}
+            mapperIsLive={isParticipating}/>
+          )}
         </div>
         <div className="chat-header">
           CHAT
@@ -101,9 +105,7 @@ class MapChat extends Component {
           <Unread count={unreadMessages} />
         </div>
         <div className="chat-messages">
-          {this.props.messages.map(message => {
-            return <Message key={message.id} {...message} />
-          })}
+          {messages.map(message => <Message key={message.id} {...message} />)}
         </div>
         <textarea className="chat-input"
           placeholder="Send a message..."
@@ -119,6 +121,8 @@ class MapChat extends Component {
 }
 
 MapChat.propTypes = {
+  conversationLive: PropTypes.bool,
+  isParticipating: PropTypes.bool,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
   leaveCall: PropTypes.func,
@@ -131,7 +135,8 @@ MapChat.propTypes = {
     id: PropTypes.number,
     image: PropTypes.string, // image url
     self: PropTypes.bool,
-    username: PropTypes.string
+    username: PropTypes.string,
+    isParticipating: PropTypes.bool
   }))
 }
 

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -1,8 +1,11 @@
 import React, { PropTypes, Component } from 'react'
+import Unread from './Unread'
+import Participant from './Participant'
+import Message from './Message'
 
 class MapChat extends Component {
-  render() {
-    const rightOffset = this.props.show ? '-300px' : '0'
+  render = () => {
+    const rightOffset = this.props.isOpen ? '-300px' : '0'
     return (
       <div className="chat-box"
         style={{ right: rightOffset }}
@@ -13,15 +16,15 @@ class MapChat extends Component {
           <div className="cursor-toggle" />
         </div>
         <div className="participants">
-				  <div className="conversation-live">
-						LIVE
+          <div className="conversation-live">
+            LIVE
 						<span className="call-action leave" onClick={this.props.leaveCall}>
 							LEAVE
 						</span>
 						<span className="call-action join"  onClick={this.props.joinCall}>
 							JOIN
 						</span>
-					</div>
+          </div>
         </div>
         <div className="chat-header">
           CHAT
@@ -39,7 +42,7 @@ class MapChat extends Component {
 }
 
 MapChat.propTypes = {
-  show: PropTypes.bool,
+  isOpen: PropTypes.bool,
   leaveCall: PropTypes.func,
   joinCall: PropTypes.func,
   participants: PropTypes.arrayOf(PropTypes.shape({

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -1,0 +1,54 @@
+import React, { PropTypes, Component } from 'react'
+
+class MapChat extends Component {
+  render() {
+    const rightOffset = this.props.show ? '-300px' : '0'
+    return (
+      <div className="chat-box"
+        style={{ right: rightOffset }}
+      >
+        <div className="junto-header">
+          PARTICIPANTS
+          <div className="video-toggle" />
+          <div className="cursor-toggle" />
+        </div>
+        <div className="participants">
+				  <div className="conversation-live">
+						LIVE
+						<span className="call-action leave" onClick={this.props.leaveCall}>
+							LEAVE
+						</span>
+						<span className="call-action join"  onClick={this.props.joinCall}>
+							JOIN
+						</span>
+					</div>
+        </div>
+        <div className="chat-header">
+          CHAT
+          <div className="sound-toggle"></div>
+        </div>
+        <div className="chat-button">
+          <div className="tooltips">Chat</div>
+          <div className="chat-unread"></div>
+        </div>
+        <div className="chat-messages"></div>
+        <textarea className="chat-input" placeholder="Send a message..." />
+      </div>
+    )
+  }
+}
+
+MapChat.propTypes = {
+  show: PropTypes.bool,
+  leaveCall: PropTypes.func,
+  joinCall: PropTypes.func,
+  participants: PropTypes.arrayOf(PropTypes.shape({
+    color: PropTypes.string // css color
+    id: PropTypes.number,
+    image: PropTypes.string, // image url
+    self: PropTypes.bool,
+    username: PropTypes.string,
+  }))
+}
+
+export default MapChat

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -8,20 +8,29 @@ class MapChat extends Component {
     super(props)
 
     this.state = {
+      unreadMessages: 0,
       open: false,
       messageText: ''
     }
   }
 
+  close = () => {
+    this.setState({open: false})
+    this.props.onClose()
+  }
+
+  open = () => {
+    this.setState({open: true, unreadMessages: 0})
+    this.props.onOpen()
+  }
+
+  newMessage = () => {
+    if (!this.state.open) this.setState({ unreadMessages: this.state.unreadMessages + 1 })
+  }
+
   toggleDrawer = () => {
-    if (this.state.open) {
-      this.setState({open: false})
-      this.props.onClose()
-    }
-    else if (!this.state.open) {
-      this.setState({open: true})
-      this.props.onOpen()
-    }
+    if (this.state.open) this.close()
+    else if (!this.state.open) this.open()
   }
 
   handleChange = key => e => {
@@ -42,6 +51,7 @@ class MapChat extends Component {
   render = () => {
     const rightOffset = this.state.open ? '0' : '-300px'
     const { videosShowing, cursorsShowing, alertSound } = this.props
+    const { unreadMessages } = this.state
     return (
       <div className="chat-box"
         style={{ right: rightOffset }}
@@ -71,7 +81,7 @@ class MapChat extends Component {
         </div>
         <div className="chat-button" onClick={this.toggleDrawer}>
           <div className="tooltips">Chat</div>
-          <Unread count={this.props.unreadMessages} />
+          <Unread count={unreadMessages} />
         </div>
         <div className="chat-messages">
           {this.props.messages.map(message => {

--- a/frontend/src/components/MapChat/index.js
+++ b/frontend/src/components/MapChat/index.js
@@ -10,7 +10,10 @@ class MapChat extends Component {
     this.state = {
       unreadMessages: 0,
       open: false,
-      messageText: ''
+      messageText: '',
+      alertSound: true, // whether to play sounds on arrival of new messages or not
+      cursorsShowing: true,
+      videosShowing:  true
     }
   }
 
@@ -33,6 +36,21 @@ class MapChat extends Component {
     else if (!this.state.open) this.open()
   }
 
+  toggleAlertSound = () => {
+    this.setState({alertSound: !this.state.alertSound})
+    this.props.soundToggleClick()
+  }
+
+  toggleCursorsShowing = () => {
+    this.setState({cursorsShowing: !this.state.cursorsShowing})
+    this.props.cursorToggleClick()
+  }
+
+  toggleVideosShowing = () => {
+    this.setState({videosShowing: !this.state.videosShowing})
+    this.props.videoToggleClick()
+  }
+
   handleChange = key => e => {
     this.setState({
       [key]: e.target.value
@@ -50,16 +68,15 @@ class MapChat extends Component {
 
   render = () => {
     const rightOffset = this.state.open ? '0' : '-300px'
-    const { videosShowing, cursorsShowing, alertSound } = this.props
-    const { unreadMessages } = this.state
+    const { videosShowing, cursorsShowing, alertSound, unreadMessages } = this.state
     return (
       <div className="chat-box"
         style={{ right: rightOffset }}
       >
         <div className="junto-header">
           PARTICIPANTS
-          <div className={`video-toggle ${videosShowing ? 'active' : ''}`} />
-          <div className={`cursor-toggle ${cursorsShowing ? 'active' : ''}`} />
+          <div onClick={this.toggleVideosShowing} className={`video-toggle ${videosShowing ? '' : 'active'}`} />
+          <div onClick={this.toggleCursorsShowing} className={`cursor-toggle ${cursorsShowing ? '' : 'active'}`} />
         </div>
         <div className="participants">
           <div className="conversation-live">
@@ -77,7 +94,7 @@ class MapChat extends Component {
         </div>
         <div className="chat-header">
           CHAT
-          <div className={`sound-toggle ${alertSound ? 'active' : ''}`}></div>
+          <div onClick={this.toggleAlertSound} className={`sound-toggle ${alertSound ? '' : 'active'}`}></div>
         </div>
         <div className="chat-button" onClick={this.toggleDrawer}>
           <div className="tooltips">Chat</div>
@@ -106,6 +123,9 @@ MapChat.propTypes = {
   onClose: PropTypes.func,
   leaveCall: PropTypes.func,
   joinCall: PropTypes.func,
+  videoToggleClick: PropTypes.func,
+  cursorToggleClick: PropTypes.func,
+  soundToggleClick: PropTypes.func, 
   participants: PropTypes.arrayOf(PropTypes.shape({
     color: PropTypes.string, // css color
     id: PropTypes.number,

--- a/realtime/realtime-server.js
+++ b/realtime/realtime-server.js
@@ -16,3 +16,4 @@ junto(io, store)
 map(io, store)
 
 io.listen(parseInt(process.env.NODE_REALTIME_PORT) || 5000)
+console.log('booting up', process.env.NODE_REALTIME_PORT || 5000)


### PR DESCRIPTION
Devin says: let's make this PR only about porting the MapChat to react, with complete feature parity. Then we can do the chat upgrades later (so maybe we can get this done by new year's, and I can do the emoji next).
TODO:

- [ ] port ChatView to react
- [ ] fix all logic so ChatView.js is just a wrapper for the react components
- [ ] test the chat view to make sure it works the same as it used to
- [ ] add chat tests to metamaps-qa-steps.md

For the next PR, here's the chat upgrades I want to do:

- [ ] add missive/emoji-mart react emoji picker
- [ ] consider if it actually is OK to store emoji directly in the db
- [ ] if not, store emoji as shortcodes in the db
- [ ] make sure shortcodes and smileys are re-rendered as emoji if typed manually
- [ ] add logic to check for @ mentions in chat messages
- [ ] send @ mentions as an event on the realtime server
- [ ] potentially update the clients when there's an @ mention.
