### PR TITLE
treat cable sub/unsub as joined/left map. fixes #1035

### DIFF
--- a/app/channels/map_channel.rb
+++ b/app/channels/map_channel.rb
@@ -3,7 +3,15 @@ class MapChannel < ApplicationCable::Channel
   # Called when the consumer has successfully
   # become a subscriber of this channel.
   def subscribed
-    return unless Pundit.policy(current_user, Map.find(params[:id])).show?
+    map = Map.find(params[:id])
+    return unless Pundit.policy(current_user, map).show?
     stream_from "map_#{params[:id]}"
+    Events::UserPresentOnMap.publish!(map, current_user)
+  end
+
+  def unsubscribed
+    map = Map.find(params[:id])
+    return unless Pundit.policy(current_user, map).show?
+    Events::UserNotPresentOnMap.publish!(map, current_user)
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -106,9 +106,6 @@ class MapsController < ApplicationController
     if params[:event] == 'conversation'
       Events::ConversationStartedOnMap.publish!(@map, current_user)
       valid_event = true
-    elsif params[:event] == 'user_presence'
-      Events::UserPresentOnMap.publish!(@map, current_user)
-      valid_event = true
     end
 
     respond_to do |format|

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Event < ApplicationRecord
-  KINDS = %w(user_present_on_map conversation_started_on_map
+  KINDS = %w(user_present_on_map user_not_present_on_map
+             conversation_started_on_map
              topic_added_to_map topic_moved_on_map topic_removed_from_map
              synapse_added_to_map synapse_removed_from_map
              topic_updated synapse_updated).freeze

--- a/app/models/events/user_not_present_on_map.rB
+++ b/app/models/events/user_not_present_on_map.rB
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Events
+  class UserNotPresentOnMap < Event
+    # after_create :notify_users!
+
+    def self.publish!(map, user)
+      create!(kind: 'user_not_present_on_map',
+              eventable: map,
+              map: map,
+              user: user)
+    end
+  end
+end

--- a/frontend/src/Metamaps/Visualize.js
+++ b/frontend/src/Metamaps/Visualize.js
@@ -149,8 +149,6 @@ const Visualize = {
       self.mGraph.graph.empty()
     }
 
-    if (self.type === 'ForceDirected' && Active.Mapper) $.post('/maps/' + Active.Map.id + '/events/user_presence')
-
     function runAnimation() {
       Loading.hide()
       // load JSON data, if it's not empty


### PR DESCRIPTION
this will set us up for, in the near future, starting to do things where we intelligently send notifications based on user presence on map or not, and also the ability to filter by changes since you last LEFT the map, not when you last joined the map, which would be kind of silly