### PR TITLE
keep permission of topic/synapse in sync with map its deferring to from beginning

### DIFF
--- a/app/models/synapse.rb
+++ b/app/models/synapse.rb
@@ -22,6 +22,7 @@ class Synapse < ApplicationRecord
     where(topic1_id: topic_id).or(where(topic2_id: topic_id))
   }
 
+  before_create :set_perm_by_defer
   after_update :after_updated
 
   delegate :name, to: :user, prefix: true
@@ -61,6 +62,12 @@ class Synapse < ApplicationRecord
     output[-2] = '.'
     output += %(\n)
     output
+  end
+  
+  protected
+  
+  def set_perm_by_defer
+    permission = defer_to_map.permission if defer_to_map
   end
 
   def after_updated

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -16,6 +16,7 @@ class Topic < ApplicationRecord
 
   belongs_to :metacode
 
+  before_create :set_perm_by_defer
   before_create :create_metamap?
   after_update :after_updated
 
@@ -133,6 +134,10 @@ class Topic < ApplicationRecord
   end
 
   protected
+
+  def set_perm_by_defer
+    permission = defer_to_map.permission if defer_to_map
+  end
 
   def create_metamap?
     return unless (link == '') && (metacode.name == 'Metamap')


### PR DESCRIPTION
this helps in the case of info being created over the api, because you don't need to fetch the map and determine its permission before you create it, you can just specify the map to sync permission with