### PR TITLE
Switch junto headings to have normal casing (not all uppercase)

### DIFF
--- a/frontend/src/components/MapView/MapChat/index.js
+++ b/frontend/src/components/MapView/MapChat/index.js
@@ -110,7 +110,7 @@ class MapChat extends Component {
         </div>
         {chatOpen && <div className="chat-panel">
           <div className="junto-header">
-            PARTICIPANTS
+            Participants
             <div onClick={this.toggleVideosShowing} className={`video-toggle ${videosShowing ? '' : 'active'}`} />
             <div onClick={this.toggleCursorsShowing} className={`cursor-toggle ${cursorsShowing ? '' : 'active'}`} />
           </div>
@@ -134,7 +134,7 @@ class MapChat extends Component {
             )}
           </div>
           <div className="chat-header">
-            CHAT
+            Chat
             <div onClick={this.toggleAlertSound} className={`sound-toggle ${alertSound ? '' : 'active'}`}></div>
           </div>
           <div className="chat-messages" ref={div => { this.messagesDiv = div }}>


### PR DESCRIPTION
I just think it looks better. 
old:
![screen shot 2017-09-25 at 3 59 24 pm](https://user-images.githubusercontent.com/1409121/30828197-e06d7ff6-a20a-11e7-823d-f6ce706a5a88.png)

proposed:
![screen shot 2017-09-25 at 4 00 06 pm](https://user-images.githubusercontent.com/1409121/30828200-e24d8c44-a20a-11e7-8c5d-d995721f659a.png)

