### PR TITLE
fix map activity emails

### DIFF
--- a/app/views/map_activity_mailer/daily_summary.html.erb
+++ b/app/views/map_activity_mailer/daily_summary.html.erb
@@ -15,22 +15,22 @@
     <%= link_to @map.name, map_url(@map) %>
   </p>
   <div>
-    <% if !@summary_data[:stats][:messages_sent].nil? %>
+    <% if @summary_data[:stats][:messages_sent] %>
       <p style="margin:6px 0;color:#a354cd;"><%= pluralize(@summary_data[:stats][:messages_sent], 'message') %></p>
     <% end %>
-    <% if !@summary_data[:stats][:topics_added].nil? %>
+    <% if @summary_data[:stats][:topics_added] %>
       <p style="margin:6px 0;color:#4FC059;"><%= pluralize(@summary_data[:stats][:topics_added], 'topic') %> added</p>
     <% end %>
-    <% if !@summary_data[:stats][:synapses_added].nil? %>
+    <% if @summary_data[:stats][:synapses_added] %>
       <p style="margin:6px 0;color:#4FC059;"><%= pluralize(@summary_data[:stats][:synapses_added], 'synapse') %> added</p>
     <% end %>
-    <% if !@summary_data[:stats][:topics_moved].nil? %>
+    <% if @summary_data[:stats][:topics_moved] %>
       <p style="margin:6px 0;color:#00BCD4;"><%= pluralize(@summary_data[:stats][:topics_moved], 'topic') %> moved</p>
     <% end %>
-    <% if !@summary_data[:stats][:topics_removed].nil? %>
+    <% if @summary_data[:stats][:topics_removed] %>
       <p style="margin:6px 0;color:#c04f4f;"><%= pluralize(@summary_data[:stats][:topics_removed], 'topic') %> removed</p>
     <% end %>
-    <% if !@summary_data[:stats][:synapses_removed].nil? %>
+    <% if @summary_data[:stats][:synapses_removed] %>
       <p style="margin:6px 0;color:#c04f4f;"><%= pluralize(@summary_data[:stats][:synapses_removed], 'synapse') %> removed</p>
     <% end %>
   </div>

--- a/app/views/map_activity_mailer/daily_summary.html.erb
+++ b/app/views/map_activity_mailer/daily_summary.html.erb
@@ -15,22 +15,22 @@
     <%= link_to @map.name, map_url(@map) %>
   </p>
   <div>
-    <% if @summary_data[:stats][:messages_sent] > 0 %>
+    <% if !@summary_data[:stats][:messages_sent].nil? %>
       <p style="margin:6px 0;color:#a354cd;"><%= pluralize(@summary_data[:stats][:messages_sent], 'message') %></p>
     <% end %>
-    <% if @summary_data[:stats][:topics_added] > 0 %>
+    <% if !@summary_data[:stats][:topics_added].nil? %>
       <p style="margin:6px 0;color:#4FC059;"><%= pluralize(@summary_data[:stats][:topics_added], 'topic') %> added</p>
     <% end %>
-    <% if @summary_data[:stats][:synapses_added] > 0 %>
+    <% if !@summary_data[:stats][:synapses_added].nil? %>
       <p style="margin:6px 0;color:#4FC059;"><%= pluralize(@summary_data[:stats][:synapses_added], 'synapse') %> added</p>
     <% end %>
-    <% if @summary_data[:stats][:topics_moved] > 0 %>
+    <% if !@summary_data[:stats][:topics_moved].nil? %>
       <p style="margin:6px 0;color:#00BCD4;"><%= pluralize(@summary_data[:stats][:topics_moved], 'topic') %> moved</p>
     <% end %>
-    <% if @summary_data[:stats][:topics_removed] > 0 %>
+    <% if !@summary_data[:stats][:topics_removed].nil? %>
       <p style="margin:6px 0;color:#c04f4f;"><%= pluralize(@summary_data[:stats][:topics_removed], 'topic') %> removed</p>
     <% end %>
-    <% if @summary_data[:stats][:synapses_removed] > 0 %>
+    <% if !@summary_data[:stats][:synapses_removed].nil? %>
       <p style="margin:6px 0;color:#c04f4f;"><%= pluralize(@summary_data[:stats][:synapses_removed], 'synapse') %> removed</p>
     <% end %>
   </div>
@@ -61,7 +61,7 @@
     </div>
   <% end %>
 
-  
+
   <% if @summary_data[:topics_removed] || @summary_data[:synapses_removed] %>
     <div style="background:rgba(192, 79, 79, 0.2); padding:8px;">
       <% if @summary_data[:topics_removed] %>

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,9 +1,14 @@
-Delayed::Worker.class_eval do
+# frozen_string_literal: true
 
-    def handle_failed_job_with_notification(job, error)
-      handle_failed_job_without_notification(job, error)
-      ExceptionNotifier.notify_exception(error)
-    end
-    alias_method_chain :handle_failed_job, :notification
-
+module ExceptionNotifierInDelayedJob
+  def handle_failed_job(job, error)
+    super
+    ExceptionNotfier.notify_exception(error)
+  end
 end
+
+Delayed::Worker.class_eval do
+  prepend ExceptionNotifierInDelayedJob
+end
+
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))

--- a/spec/views/map_activity_mailer/daily_summary.html.erb_spec.rb
+++ b/spec/views/map_activity_mailer/daily_summary.html.erb_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'map_activity_mailer/daily_summary.html.erb' do
+  it 'displays messages sent' do
+    assign(:user, create(:user))
+    assign(:map, create(:map))
+    assign(:summary_data, stats: {
+             messages_sent: 5
+           })
+
+    render
+
+    expect(rendered).to match(/5 messages/)
+  end
+end


### PR DESCRIPTION
the reason we weren't seeing the error messages is being they would be showing up in the DelayedJob logs, since delayedjob is the one actually sending them 
(because we use deliver_later in the rake task)

and the reason why I didn't catch the template error is because in my test case, all the different possible changes occurred, not just some of them. If any type of change had not occurred, I would have realized that this would fail in that situation