### PR TITLE
MapInfoBox was closing annoyingly after you left initial map then opened new one

### DIFF
--- a/frontend/src/Metamaps/Map/InfoBox.js
+++ b/frontend/src/Metamaps/Map/InfoBox.js
@@ -116,7 +116,9 @@ const InfoBox = {
   },
   attachEventListeners: function() {
     var self = InfoBox
-
+    $('.mapInfoBox').click(function(event) {
+      event.stopPropagation()
+    })
     $('.mapInfoBox.canEdit .best_in_place').best_in_place()
 
     // because anyone who can edit the map can change the map title


### PR DESCRIPTION
this is the same as on the initial page load (what happens in the 'init' function)