### PR TITLE
add normal/API endpoints for attachments

### DIFF
--- a/app/controllers/api/v2/attachments_controller.rb
+++ b/app/controllers/api/v2/attachments_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Api
+  module V2
+    class AttachmentsController < RestfulController
+      def searchable_columns
+        [:file]
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/attachments_controller.rb
+++ b/app/controllers/api/v2/attachments_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Api
   module V2
     class AttachmentsController < RestfulController

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class AttachmentsController < ApplicationController
+  before_action :set_attachment, only: [:destroy]
+  after_action :verify_authorized
+
+  def create
+    @attachment = Attachment.new(attachment_params)
+    authorize @attachment
+
+    respond_to do |format|
+      if @attachment.save
+        format.json { render json: @attachment, status: :created }
+      else
+        format.json { render json: @attachment.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @attachment.destroy
+    respond_to do |format|
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def set_attachment
+    @attachment = Attachment.find(params[:id])
+    authorize @attachment
+  end
+
+  def attachment_params
+    params.require(:attachment).permit(:id, :file, :attachable_id, :attachable_type)
+  end
+end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AttachmentsController < ApplicationController
   before_action :set_attachment, only: [:destroy]
   after_action :verify_authorized

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -15,7 +15,9 @@ class Attachment < ApplicationRecord
                       end
                     }
 
+  validates :attachable, presence: true
   validates_attachment_content_type :file, content_type: Attachable.allowed_types
+  validates_attachment_size :file, in: 0.megabytes..5.megabytes
 
   def image?
     Attachable.image_types.include?(file.instance.file_content_type)

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -33,7 +33,8 @@ module Attachable
     end
 
     def audio_types
-      ['audio/ogg', 'audio/mp3']
+      # .ogg files might be labelled as video
+      ['audio/ogg', 'video/ogg', 'audio/mpeg', 'audio/wav', 'video/webm']
     end
 
     def text_types

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -69,10 +69,23 @@ class Topic < ApplicationRecord
     Pundit.policy_scope(user, maps).map(&:id)
   end
 
+  def attachments_json
+    attachments.map do |a|
+      {
+        id: a.id,
+        file_name: a.file_file_name,
+        content_type: a.file_content_type,
+        file_size: a.file_file_size,
+        url: a.file.url
+      }
+    end
+  end
+
   def as_json(options = {})
     super(methods: %i[user_name user_image collaborator_ids])
       .merge(inmaps: inmaps(options[:user]), inmapsLinks: inmaps_links(options[:user]),
-             map_count: map_count(options[:user]), synapse_count: synapse_count(options[:user]))
+             map_count: map_count(options[:user]), synapse_count: synapse_count(options[:user]),
+             attachments: attachments_json)
   end
 
   def as_rdf

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class AttachmentPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.where(attachable: TopicPolicy::Scope.new(user, Topic).resolve)
+    end
+  end
+
+  def index?
+    true
+  end
+
+  def create?
+    Pundit.policy(user, record.attachable).update?
+  end
+
+  def destroy?
+    Pundit.policy(user, record.attachable).update?
+  end
+end

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AttachmentPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve

--- a/app/serializers/api/v2/attachment_serializer.rb
+++ b/app/serializers/api/v2/attachment_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Api
+  module V2
+    class AttachmentSerializer < ApplicationSerializer
+      attributes :id,
+                 :file,
+                 :attachable_type,
+                 :attachable_id,
+                 :created_at,
+                 :updated_at
+    end
+  end
+end

--- a/app/serializers/api/v2/attachment_serializer.rb
+++ b/app/serializers/api/v2/attachment_serializer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Api
   module V2
     class AttachmentSerializer < ApplicationSerializer

--- a/app/serializers/api/v2/topic_serializer.rb
+++ b/app/serializers/api/v2/topic_serializer.rb
@@ -14,7 +14,8 @@ module Api
       def self.embeddable
         {
           user: {},
-          metacode: {}
+          metacode: {},
+          attachments: {}
         }
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Metamaps::Application.routes.draw do
   root to: 'main#home', via: :get
   get 'request', to: 'main#requestinvite', as: :request
 
-  resources :attachments, only: [:create, :destroy], shallow: true
+  resources :attachments, only: %i[create destroy], shallow: true
 
   namespace :explore do
     get 'active'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Metamaps::Application.routes.draw do
   root to: 'main#home', via: :get
   get 'request', to: 'main#requestinvite', as: :request
 
+  resources :attachments, only: [:create, :destroy], shallow: true
+
   namespace :explore do
     get 'active'
     get 'featured'
@@ -121,6 +123,7 @@ Metamaps::Application.routes.draw do
 
   namespace :api, path: '/api', default: { format: :json } do
     namespace :v2, path: '/v2' do
+      resources :attachments, only: %i[index show]
       resources :metacodes, only: %i[index show]
       resources :mappings, only: %i[index create show update destroy]
       resources :maps, only: %i[index create show update destroy] do

--- a/doc/api/api.raml
+++ b/doc/api/api.raml
@@ -22,6 +22,7 @@ traits:
   searchable: !include traits/searchable.raml
 
 schemas:
+  attachment: !include schemas/_attachment.json
   map: !include schemas/_map.json
   mapping: !include schemas/_mapping.json
   metacode: !include schemas/_metacode.json
@@ -35,6 +36,7 @@ schemas:
 #  item: !include resourceTypes/item.raml
 #  collection: !include resourceTypes/collection.raml
 
+/attachments : !include api/attachments.raml
 /maps: !include apis/maps.raml
 /mappings: !include apis/mappings.raml
 /metacodes: !include apis/metacodes.raml

--- a/doc/api/api.raml
+++ b/doc/api/api.raml
@@ -36,7 +36,7 @@ schemas:
 #  item: !include resourceTypes/item.raml
 #  collection: !include resourceTypes/collection.raml
 
-/attachments : !include api/attachments.raml
+/attachments: !include apis/attachments.raml
 /maps: !include apis/maps.raml
 /mappings: !include apis/mappings.raml
 /metacodes: !include apis/metacodes.raml

--- a/doc/api/apis/attachments.raml
+++ b/doc/api/apis/attachments.raml
@@ -1,0 +1,16 @@
+get:
+  is: [ searchable: { searchFields: "file" }, orderable, pageable ]
+  securedBy: [ null, token, oauth_2_0 ]
+  responses:
+    200:
+      body:
+        application/json:
+          example: !include ../examples/attachments.json
+/{id}:
+  get:
+    securedBy: [ null, token, oauth_2_0 ]
+    responses:
+      200:
+        body:
+          application/json:
+            example: !include ../examples/attachment.json

--- a/doc/api/examples/attachment.json
+++ b/doc/api/examples/attachment.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": 1,
+    "file": "https://example.org/file.png",
+    "attachable_type": "Topic",
+    "attachable_id": 187,
+    "created_at": "2017-03-01T05:48:09.533Z",
+    "updated_at": "2017-03-01T05:48:09.533Z"
+  }
+}

--- a/doc/api/examples/attachments.json
+++ b/doc/api/examples/attachments.json
@@ -1,0 +1,28 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "file": "https://example.org/file.png",
+      "attachable_type": "Topic",
+      "attachable_id": 187,
+      "created_at": "2017-03-01T05:48:09.533Z",
+      "updated_at": "2017-03-01T05:48:09.533Z"
+    },
+    {
+      "id": 2,
+      "file": "https://example.org/file.docx",
+      "attachable_type": "Message",
+      "attachable_id": 1043,
+      "created_at": "2017-03-01T05:50:19.533Z",
+      "updated_at": "2017-03-01T05:50:19.533Z"
+    }
+  ],
+  "page": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": 0,
+    "total_pages": 156,
+    "total_count": 312,
+    "per": 2
+  }
+}

--- a/doc/api/schemas/_attachment.json
+++ b/doc/api/schemas/_attachment.json
@@ -1,0 +1,34 @@
+{
+  "name": "Attachment",
+  "type": "object",
+  "properties": {
+    "id": {
+      "$ref": "_id.json"
+    },
+    "file": {
+      "format": "uri",
+      "type": "string"
+    },
+    "attachable_type": {
+      "pattern": "(Topic|Message)",
+      "type": "string"
+    },
+    "attachable_id": {
+      "$ref": "_id.json"
+    },
+    "created_at": {
+      "$ref": "_datetimestamp.json"
+    },
+    "updated_at": {
+      "$ref": "_datetimestamp.json"
+    }
+  },
+  "required": [
+    "id",
+    "file",
+    "attachable_type",
+    "attachable_id",
+    "created_at",
+    "updated_at"
+  ]
+}

--- a/doc/api/schemas/attachment.json
+++ b/doc/api/schemas/attachment.json
@@ -1,0 +1,12 @@
+{
+  "name": "Attachment Envelope",
+  "type": "object",
+  "properties": {
+    "data": {
+      "$ref": "_attachment.json"
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/doc/api/schemas/attachments.json
+++ b/doc/api/schemas/attachments.json
@@ -1,0 +1,19 @@
+{
+  "name": "Attachments",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "_attachment.json"
+      }
+    },
+    "page": {
+      "$ref": "_page.json"
+    }
+  },
+  "required": [
+    "data",
+    "page"
+  ]
+}

--- a/spec/api/v2/attachments_api_spec.rb
+++ b/spec/api/v2/attachments_api_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'topics API', type: :request do
+  let(:user) { create(:user, admin: true) }
+  let(:token) { create(:token, user: user).token }
+  let(:attachment) { create(:attachment) }
+
+  it 'GET /api/v2/attachments' do
+    create_list(:attachment, 5)
+    get '/api/v2/attachments', params: { access_token: token }
+
+    expect(response).to have_http_status(:success)
+    expect(response).to match_json_schema(:attachments)
+    expect(JSON.parse(response.body)['data'].count).to eq 5
+  end
+
+  it 'GET /api/v2/attachments/:id' do
+    get "/api/v2/attachments/#{attachment.id}"
+
+    expect(response).to have_http_status(:success)
+    expect(response).to match_json_schema(:attachment)
+    expect(JSON.parse(response.body)['data']['id']).to eq attachment.id
+  end
+
+  context 'RAML example' do
+    let(:resource) { get_json_example(:attachment) }
+    let(:collection) { get_json_example(:attachments) }
+
+    it 'resource matches schema' do
+      expect(resource).to match_json_schema(:attachment)
+    end
+
+    it 'collection matches schema' do
+      expect(collection).to match_json_schema(:attachments)
+    end
+  end
+end

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :attachment do
+    association :attachable, factory: :topic
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -9,4 +9,20 @@ RSpec.describe Topic, type: :model do
   it { is_expected.to have_many :mappings }
   it { is_expected.to validate_presence_of :permission }
   it { is_expected.to validate_inclusion_of(:permission).in_array Perm::ISSIONS.map(&:to_s) }
+
+  describe 'attachments_json' do
+    let (:attachments) do
+      create_list(:attachment, 1,
+                  file_file_name: 'file_name',
+                  file_content_type: 'text/plain',
+                  file_file_size: '100')
+    end
+    let (:topic) { create(:topic, attachments: attachments) }
+    let(:json) { topic.attachments_json }
+
+    it 'returns correct json' do
+      expect(json.first[:id]).to equal(attachments.first.id)
+      binding.pry
+    end
+  end
 end

--- a/spec/policies/map_policy_spec.rb
+++ b/spec/policies/map_policy_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MapPolicy, type: :policy do
     context 'private' do
       let(:map) { create(:map, permission: :private) }
       permissions :show?, :create?, :update?, :destroy? do
-        it 'permits access' do
+        it 'denies access' do
           expect(subject).to_not permit(nil, map)
         end
       end


### PR DESCRIPTION
Split out some of the backend work from https://github.com/metamaps/metamaps/pull/1112

This PR just adds the controller endpoints and the API endpoints so the other
PR can focus on frontend work

TODO

- [ ] sanity test with `rails server`