### PR TITLE
Change log level of Metamaps.Debug

### DIFF
--- a/frontend/src/Metamaps/Debug.js
+++ b/frontend/src/Metamaps/Debug.js
@@ -1,9 +1,9 @@
 const Debug = function(arg = window.Metamaps) {
   if (arg === undefined && typeof window !== 'undefined') arg = window.Metamaps
-  console.debug(arg)
-  console.debug(`Metamaps Version: ${arg.ServerData.VERSION}`)
-  console.debug(`Build: ${arg.ServerData.BUILD}`)
-  console.debug(`Last Updated: ${arg.ServerData.LAST_UPDATED}`)
+  console.log(arg)
+  console.log(`Metamaps Version: ${arg.ServerData.VERSION}`)
+  console.log(`Build: ${arg.ServerData.BUILD}`)
+  console.log(`Last Updated: ${arg.ServerData.LAST_UPDATED}`)
 }
 
 export default Debug


### PR DESCRIPTION
debug log level is invisible in Chrome by default, which is confusing