### PR TITLE
ensure ta.eventable is present

### DIFF
--- a/app/services/map_activity_service.rb
+++ b/app/services/map_activity_service.rb
@@ -55,7 +55,7 @@ class MapActivityService
     topics_removed_events.each do |ta|
       num_adds = topics_added_events.where(eventable_id: ta.eventable_id).count
       num_removes = topics_removed_events.where(eventable_id: ta.eventable_id).count
-      if num_removes > num_adds && TopicPolicy.new(user, ta.eventable).show?
+      if num_removes > num_adds && ta.eventable.present? && TopicPolicy.new(user, ta.eventable).show?
         topics_removed_to_include[ta.eventable_id] = ta
       end
     end


### PR DESCRIPTION
avoids errors when running map-follow-notifications script. Stack trace:

NoMethodError: undefined method 'defer_to_map' for nil:NilClass
/home/metamaps/metamaps.cc/app/policies/topic_policy.rb:32:in 'show?'
/home/metamaps/metamaps.cc/app/services/map_activity_service.rb:58:in 'block in summarize_data'
/usr/local/rvm/gems/ruby-2.3.0@metamaps/gems/activerecord-5.0.5/lib/active_record/relation/delegation.rb:38:in 'each'
/usr/local/rvm/gems/ruby-2.3.0@metamaps/gems/activerecord-5.0.5/lib/active_record/relation/delegation.rb:38:in 'each'
/home/metamaps/metamaps.cc/app/services/map_activity_service.rb:55:in 'summarize_data'
/home/metamaps/metamaps.cc/lib/tasks/emails.rake:17:in 'block in summarize_map_activity'